### PR TITLE
Ensure case-sensitive folder names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@ __pycache__/
 data/current.json
 .vscode/
 calls.txt
-logs/LVP_log*
+logs/LVP_Log*
 capture/*.tiff
 script_testing.py

--- a/lvp_logger.py
+++ b/lvp_logger.py
@@ -44,7 +44,7 @@ if not os.path.exists("logs/LVP_Log"):
     os.makedirs("logs/LVP_Log")
 
 # file to which messages are logged 
-LOG_FILE = 'logs/LVP_log/lumaviewpro.log'
+LOG_FILE = 'logs/LVP_Log/lumaviewpro.log'
 
 # CustomFormatter class enables change in log format depending on log level 
 class CustomFormatter(logging.Formatter):


### PR DESCRIPTION
On MacOS and Linux operating systems, the folder names are case-sensitive. Make it so.