### PR TITLE
Adding option to save a 12-bit (16-bit uint) image

### DIFF
--- a/lumascope_api.py
+++ b/lumascope_api.py
@@ -184,7 +184,7 @@ class Lumascope():
 
         return f'{path[:under_idx]}_{new_file_id}.{file_extension}'
 
-    def save_image(self, array, save_folder = './capture', file_root = 'img_', append = 'ms', color = 'BF'):
+    def save_image(self, array, save_folder = './capture', file_root = 'img_', append = 'ms', color = 'BF', full_bit_depth:bool = False):
         """CAMERA FUNCTIONS
         save image (as array) to file
         """
@@ -222,7 +222,10 @@ class Lumascope():
             path = self.get_next_save_path(path)
 
         try:
-            cv2.imwrite(path, img.astype(np.uint8))
+            if full_bit_depth:
+                cv2.imwrite(path, img.astype(cv2.cv_16u)) # 12-bit can be saved as 16-bit
+            else:
+                cv2.imwrite(path, img.astype(np.uint8))   # Downscale to 8 bit
             logger.info(f'[SCOPE API ] Saving Image to {path}')
         except:
             logger.exception("[SCOPE API ] Error: Unable to save. Perhaps save folder does not exist?")


### PR DESCRIPTION
For the LS820/850 the camera is 12-bit pixel depth, but I think the API only saves it as 8-bit pixel depth. This defeats the purpose of having a 12-bit camera.

I've added an optional flag to the API that allows the whole 12-bit depth to be saved (into a 16-bit uint).
