### PR TITLE
Hide tiling control based in selected microscope model

### DIFF
--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -1042,21 +1042,20 @@
         # Tiling
         BoxLayout:
             orientation: 'horizontal'
-            size_hint_y: None
-            height: '30dp'
+			id: tiling_box_layout_id
+            size_hint_y: None if self.visible else 0
+            height: '30dp' if self.visible else 0
+			opacity: 1 if self.visible else 0
             spacing: '5dp'
+			visible: True
            
             Label:
                 text: 'Tiling'
-				id: tiling_selection_label
-				size_hint_y: None if self.visible else 0
-				height: '30dp' if self.visible else 0
-				opacity: 1 if self.visible else 0
-				disabled: not self.visible
+				size_hint_y: None
+				height: '30dp'
                 size_hint_x: None
                 width: '75dp'
                 font_size: '12sp'
-				visible: True
                 
             # Select tiling size
             Spinner:
@@ -1064,15 +1063,11 @@
                 sync_height: True
                 text: 'New'
                 font_size: '12dp'
-                # size_hint_y: None if self.visible else 0
-                height: '30dp' if self.visible else 0
-				opacity: 1 if self.visible else 0
-				disabled: not self.visible
+                size_hint_y: None
+                height: '30dp'
                 text_autoupdate: True
                 on_text: root.select_tiling_size()
-                #text: '1x1'
                 values: '1x1', '2x2', '3x3', '4x4', '5x5', '6x6', '7x7', '8x8', '9x9'
-				visible: True
                 
                 
         # # Z-stack

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -1048,9 +1048,15 @@
            
             Label:
                 text: 'Tiling'
+				id: tiling_selection_label
+				size_hint_y: None if self.visible else 0
+				height: '30dp' if self.visible else 0
+				opacity: 1 if self.visible else 0
+				disabled: not self.visible
                 size_hint_x: None
                 width: '75dp'
                 font_size: '12sp'
+				visible: True
                 
             # Select tiling size
             Spinner:
@@ -1058,12 +1064,15 @@
                 sync_height: True
                 text: 'New'
                 font_size: '12dp'
-                size_hint_y: None
-                height: '30dp'
+                # size_hint_y: None if self.visible else 0
+                height: '30dp' if self.visible else 0
+				opacity: 1 if self.visible else 0
+				disabled: not self.visible
                 text_autoupdate: True
                 on_text: root.select_tiling_size()
                 #text: '1x1'
                 values: '1x1', '2x2', '3x3', '4x4', '5x5', '6x6', '7x7', '8x8', '9x9'
+				visible: True
                 
                 
         # # Z-stack

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -619,6 +619,12 @@ class MotionSettings(BoxLayout):
         for turret_id in ('turret_selection_label', 'turret_btn_box'):
             vert_control.ids[turret_id].visible = visible
 
+    
+    def set_tiling_control_visibility(self, visible: bool) -> None:
+        vert_control = self.ids['protocol_settings_id']
+        for tiling_id in ('tiling_selection_label', 'tiling_size_spinner'):
+            vert_control.ids[tiling_id].visible = visible
+
 
     # Hide (and unhide) motion settings
     def toggle_settings(self):
@@ -3262,6 +3268,7 @@ class MicroscopeSettings(BoxLayout):
         motion_settings =  lumaview.ids['motionsettings_id']
         motion_settings.set_turret_control_visibility(visible=selected_scope_config['Turret'])
         motion_settings.set_xystage_control_visibility(visible=selected_scope_config['XYStage'])
+        motion_settings.set_tiling_control_visibility(visible=selected_scope_config['XYStage'])
 
         protocol_settings = lumaview.ids['motionsettings_id'].ids['protocol_settings_id']
         protocol_settings.set_labware_selection_visibility(visible=selected_scope_config['XYStage'])

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -622,8 +622,11 @@ class MotionSettings(BoxLayout):
     
     def set_tiling_control_visibility(self, visible: bool) -> None:
         vert_control = self.ids['protocol_settings_id']
-        for tiling_id in ('tiling_selection_label', 'tiling_size_spinner'):
+        for tiling_id in ('tiling_box_layout_id',):
             vert_control.ids[tiling_id].visible = visible
+
+        if not visible:
+            vert_control.ids['tiling_size_spinner'].text = '1x1'
 
 
     # Hide (and unhide) motion settings


### PR DESCRIPTION
Hides the tiling control when the selected model is an 820. Addresses: https://github.com/EtalumaSupport/LumaViewPro/issues/291