### PR TITLE
Fix crash when adjusting frame size

### DIFF
--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -3306,8 +3306,8 @@ class MicroscopeSettings(BoxLayout):
         global lumaview
         global settings
 
-        w = int(self.ids['frame_width'].text)
-        h = int(self.ids['frame_height'].text)
+        w = int(self.ids['frame_width_id'].text)
+        h = int(self.ids['frame_height_id'].text)
 
         width = int(min(int(w), lumaview.scope.get_max_width())/4)*4
         height = int(min(int(h), lumaview.scope.get_max_height())/4)*4
@@ -3315,8 +3315,8 @@ class MicroscopeSettings(BoxLayout):
         settings['frame']['width'] = width
         settings['frame']['height'] = height
 
-        self.ids['frame_width'].text = str(width)
-        self.ids['frame_height'].text = str(height)
+        self.ids['frame_width_id'].text = str(width)
+        self.ids['frame_height_id'].text = str(height)
 
         lumaview.scope.set_frame_size(width, height)
 


### PR DESCRIPTION
Fix issue causing application to crash when frame size is modified.  Addresses https://github.com/EtalumaSupport/LumaViewPro/issues/295.