### PR TITLE
Separate folders per channel, log fixes, Z-axis grease...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ __pycache__/
 data/current.json
 .vscode/
 calls.txt
-logs/LVP_log*
+logs/LVP_Log*
 capture/**/*.tiff
 capture/**/*.tsv
 script_testing.py

--- a/data/settings.json
+++ b/data/settings.json
@@ -113,5 +113,6 @@
         "default": {
             "level": "INFO"
         }
-    }
+    },
+    "mode": "normal"
 }

--- a/data/settings.json
+++ b/data/settings.json
@@ -108,5 +108,10 @@
             "target_brightness": 0.3,
             "max_duration_seconds": 1.0
         }
+    },
+    "logging": {
+        "default": {
+            "level": "INFO"
+        }
     }
 }

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -1089,6 +1089,26 @@
                 halign: 'left'
                 valign: 'middle'
                 text_size: self.size
+		
+		# Separate Folders
+        BoxLayout:
+            orientation: 'horizontal'
+            size_hint_y: None
+            height: '30dp'
+            spacing: '5dp'
+                           
+            CheckBox:
+                id: protocol_channel_per_folder_id
+                size_hint_x: None
+                width: '30dp'
+                active: False
+
+            Label:
+                text: 'Save channels in separate folders'
+                font_size: '12sp'
+                halign: 'left'
+                valign: 'middle'
+                text_size: self.size
         
         # # Multiple exposure
         # BoxLayout:

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -2009,37 +2009,7 @@
 					halign: 'left'
 					valign: 'middle'
 					text_size: self.size
-				
-			FloatLayout:
-				padding: '0dp'
-				spacing: '5dp'
-				size_hint_y: None
-				height: '128dp'
-
-				Histogram:
-					id: histo_id
-					pos_hint:{'center_x':0.5, 'center_y':0.5}
-					bg_color: root.bg_color
-					layer: root.layer
-
-			Label:
-			    id: image_stats_mean_id
-				height: '0dp'
-				pos_hint:{'left': 0.1}
-				halign: 'left'
-				size_hint_x: None
-				size_hint_y: None
-				text: ''
-
-			Label:
-			    id: image_stats_stddev_id
-				height: '0dp'
-				pos_hint:{'left': 0.1}
-				halign: 'left'
-				size_hint_x: None
-				size_hint_y: None
-				text: ''
-
+			
 			# Protocol Settings
 			Label:
 				canvas:
@@ -2085,6 +2055,36 @@
 					halign: 'left'
 					valign: 'middle'
 					text_size: self.size
+				
+			FloatLayout:
+				padding: '0dp'
+				spacing: '5dp'
+				size_hint_y: None
+				height: '128dp'
+
+				Histogram:
+					id: histo_id
+					pos_hint:{'center_x':0.5, 'center_y':0.5}
+					bg_color: root.bg_color
+					layer: root.layer
+
+			Label:
+			    id: image_stats_mean_id
+				height: '0dp'
+				pos_hint:{'left': 0.1}
+				halign: 'left'
+				size_hint_x: None
+				size_hint_y: None
+				text: ''
+
+			Label:
+			    id: image_stats_stddev_id
+				height: '0dp'
+				pos_hint:{'left': 0.1}
+				halign: 'left'
+				size_hint_x: None
+				size_hint_y: None
+				text: ''
 
 			Label:
 

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -72,7 +72,7 @@
         orientation: 'horizontal'
         padding: '5dp'
         spacing: '5dp'
-        pos: (root.width-7*40)/2, 0
+        pos: (root.width-9*40)/2, 0
 
         FolderChooseBTN:
             id: live_folder_btn

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -1977,6 +1977,24 @@
 					bg_color: root.bg_color
 					layer: root.layer
 
+			Label:
+			    id: image_stats_mean_id
+				height: '0dp'
+				pos_hint:{'left': 0.1}
+				halign: 'left'
+				size_hint_x: None
+				size_hint_y: None
+				text: ''
+
+			Label:
+			    id: image_stats_stddev_id
+				height: '0dp'
+				pos_hint:{'left': 0.1}
+				halign: 'left'
+				size_hint_x: None
+				size_hint_y: None
+				text: ''
+
 			# Protocol Settings
 			Label:
 				canvas:

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -1647,6 +1647,25 @@
 		font_size: '12sp'
 		on_release: self.choose('save_settings')
 
+	BoxLayout:
+        orientation: 'horizontal'
+        size_hint_y: None
+        height: '30dp'
+		Label:
+			font_size: '12sp'
+			text: 'Enable Crosshairs'
+			halign: 'left'
+			valign: 'middle'
+			text_size: self.size
+		ToggleButton:
+			id: enable_crosshairs_btn
+			size_hint: None, None
+			size: '45dp', '30dp'
+			border: 0, 0, 0, 0
+			valign: 'middle'
+			background_normal: './data/icons/ToggleL.png'
+			background_down: './data/icons/ToggleRW.png'
+
 	Label:
 
 # LayerControl - Settings for Layers within ImageSettings

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -1692,6 +1692,30 @@
 			background_normal: './data/icons/ToggleL.png'
 			background_down: './data/icons/ToggleRW.png'
 
+	# Label:
+	# 	height: '30dp'
+		
+	BoxLayout:
+		id: enable_bullseye_box_id
+		opacity: 0
+        orientation: 'horizontal'
+        size_hint_y: None
+        height: '0dp'
+		Label:
+			font_size: '12sp'
+			text: 'Enable Bullseye Mode'
+			halign: 'left'
+			valign: 'middle'
+			text_size: self.size
+		ToggleButton:
+			id: enable_bullseye_btn_id
+			size_hint: None, None
+			size: '45dp', '30dp'
+			border: 0, 0, 0, 0
+			valign: 'middle'
+			background_normal: './data/icons/ToggleL.png'
+			background_down: './data/icons/ToggleRW.png'
+
 	Label:
 
 # LayerControl - Settings for Layers within ImageSettings

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -1691,9 +1691,13 @@
 			valign: 'middle'
 			background_normal: './data/icons/ToggleL.png'
 			background_down: './data/icons/ToggleRW.png'
+			on_release: root.update_crosshairs_state()
 
-	# Label:
-	# 	height: '30dp'
+	BoxLayout:
+		height: '30dp'
+		size_hint_y: None
+		orientation: 'horizontal'
+		opacity: 0
 		
 	BoxLayout:
 		id: enable_bullseye_box_id
@@ -1715,6 +1719,7 @@
 			valign: 'middle'
 			background_normal: './data/icons/ToggleL.png'
 			background_down: './data/icons/ToggleRW.png'
+			on_release: root.update_bullseye_state()
 
 	Label:
 

--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -1109,7 +1109,7 @@
                 halign: 'left'
                 valign: 'middle'
                 text_size: self.size
-        
+
         # # Multiple exposure
         # BoxLayout:
         #     orientation: 'horizontal'
@@ -1187,6 +1187,32 @@
 	        height: '30dp'
 			font_size: '12sp'
 			on_release: root.run_protocol()
+
+		# Engineering mode option
+        BoxLayout:
+		    id: protocol_disable_image_saving_box_id
+			height: '0dp'
+            orientation: 'horizontal'
+            size_hint_y: None
+            height: '0dp'
+            spacing: '5dp'
+			opacity: 0
+                           
+            CheckBox:
+                id: protocol_disable_image_saving_id
+				height: '0dp'
+                size_hint_x: None
+                width: '30dp'
+                active: False
+
+            Label:
+			    id: protocol_disable_image_saving_label_id
+				height: '0dp'
+                text: 'Disable image saving'
+                font_size: '12sp'
+                halign: 'left'
+                valign: 'middle'
+                text_size: self.size
 
 		Label:
 

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -193,6 +193,8 @@ class ScopeDisplay(Image):
     def __init__(self, **kwargs):
         super(ScopeDisplay,self).__init__(**kwargs)
         logger.info('[LVP Main  ] ScopeDisplay.__init__()')
+        self.use_bullseye = False
+        self.use_crosshairs = False
         self.start()
 
     def start(self, fps = 10):
@@ -286,22 +288,12 @@ class ScopeDisplay(Image):
         global lumaview
         global debug_counter
 
-        use_bullseye = False
-        use_crosshairs = False
-
-        if lumaview.ids['motionsettings_id'].ids['microscope_settings_id'].ids['enable_crosshairs_btn'].state == 'down':
-            use_crosshairs = True
-
         if lumaview.scope.camera.active != False:
             image = lumaview.scope.get_image()
             if image is False:
                 return
             
-            
-            
             if ENGINEERING_MODE == True:
-                if lumaview.ids['motionsettings_id'].ids['microscope_settings_id'].ids['enable_bullseye_btn_id'].state == 'down':
-                    use_bullseye = True
 
                 debug_counter += 1
                 if debug_counter == 10:
@@ -319,18 +311,18 @@ class ScopeDisplay(Image):
                         lumaview.ids['imagesettings_id'].ids[open_layer].ids['image_stats_mean_id'].text = f"Mean: {mean}"
                         lumaview.ids['imagesettings_id'].ids[open_layer].ids['image_stats_stddev_id'].text = f"StdDev: {stddev}"
 
-                    if use_bullseye:
+                    if self.use_bullseye:
                         image_bullseye = self.transform_to_bullseye(image=image)
 
-                        if use_crosshairs:
+                        if self.use_crosshairs:
                             image_bullseye = self.add_crosshairs(image=image_bullseye)
 
                         texture = Texture.create(size=(image_bullseye.shape[1],image_bullseye.shape[0]), colorfmt='rgb')
                         texture.blit_buffer(image_bullseye.tobytes(), colorfmt='rgb', bufferfmt='ubyte')
                         self.texture = texture
                 
-            if not use_bullseye:
-                if use_crosshairs:
+            if not self.use_bullseye:
+                if self.use_crosshairs:
                     image = self.add_crosshairs(image=image)
 
                 # Convert to texture for display (using OpenGL)
@@ -3770,6 +3762,20 @@ class MicroscopeSettings(BoxLayout):
                 logger.exception('[LVP Main  ] Incompatible JSON file for Microscope Settings')
         
         self.set_ui_features_for_scope()
+
+
+    def update_bullseye_state(self):
+        if self.ids['enable_bullseye_btn_id'].state == 'down':
+            lumaview.ids['viewer_id'].ids['scope_display_id'].use_bullseye = True
+        else:
+            lumaview.ids['viewer_id'].ids['scope_display_id'].use_bullseye = False
+
+    
+    def update_crosshairs_state(self):
+        if self.ids['enable_crosshairs_btn'].state == 'down':
+            lumaview.ids['viewer_id'].ids['scope_display_id'].use_crosshairs = True
+        else:
+            lumaview.ids['viewer_id'].ids['scope_display_id'].use_crosshairs = False
 
 
     # Save settings to JSON file

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -221,13 +221,13 @@ class ScopeDisplay(Image):
         center_x = round(width/2)
         center_y = round(height/2)
 
-        # Crosshairs
+        # Crosshairs - 2 pixels wide
         if is_color:
-            image[:,center_x,:] = 255
-            image[center_y,:,:] = 255
+            image[:,center_x-1:center_x+1,:] = 255
+            image[center_y-1:center_y+1,:,:] = 255
         else:
-            image[:,center_x] = 255
-            image[center_y,:] = 255
+            image[:,center_x-1:center_x+1] = 255
+            image[center_y-1:center_y+1,:] = 255
 
         # Radiating circles
         num_circles = 4
@@ -236,6 +236,10 @@ class ScopeDisplay(Image):
         for i in range(num_circles):
             radius = (i+1) * circle_spacing
             rr, cc = skimage.draw.circle_perimeter(center_y, center_x, radius=radius, shape=image.shape)
+            image[rr, cc] = 255
+
+            # To make circles 2 pixel wide...
+            rr, cc = skimage.draw.circle_perimeter(center_y, center_x, radius=radius+1, shape=image.shape)
             image[rr, cc] = 255
 
         return image
@@ -296,8 +300,10 @@ class ScopeDisplay(Image):
             if ENGINEERING_MODE == True:
 
                 debug_counter += 1
-                if debug_counter == 10:
+                if debug_counter == 30:
                     debug_counter = 0
+
+                if debug_counter % 10 == 0:
                     mean = round(np.mean(a=image), 2)
                     stddev = round(np.std(a=image), 2)
                     open_layer = None
@@ -311,6 +317,7 @@ class ScopeDisplay(Image):
                         lumaview.ids['imagesettings_id'].ids[open_layer].ids['image_stats_mean_id'].text = f"Mean: {mean}"
                         lumaview.ids['imagesettings_id'].ids[open_layer].ids['image_stats_stddev_id'].text = f"StdDev: {stddev}"
 
+                if debug_counter % 3 == 0:
                     if self.use_bullseye:
                         image_bullseye = self.transform_to_bullseye(image=image)
 

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -1390,7 +1390,16 @@ class ImageSettings(BoxLayout):
     def _init_ui(self, dt=0):
         self.assign_led_button_down_images()
         self.accordion_collapse()
+        self.set_layer_exposure_range()
+
         
+    def set_layer_exposure_range(self):
+        for layer in common_utils.get_fluorescence_layers():
+            lumaview.ids['imagesettings_id'].ids[layer].ids['exp_slider'].max = 1000
+
+        for layer in common_utils.get_transmitted_layers():
+            lumaview.ids['imagesettings_id'].ids[layer].ids['exp_slider'].max = 200
+
 
     def assign_led_button_down_images(self):
         led_button_down_background_map = {

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -38,6 +38,7 @@ June 24, 2023
 '''
 
 # General
+import logging
 import datetime
 import os
 import pathlib
@@ -4145,11 +4146,29 @@ class FileSaveBTN(Button):
                 video_creation_controls.set_output_file_loc(file_loc=filepath)
 
 
+def load_log_level():
+    for settings_file in ("./data/current.json", "./data/settings.json"):
+        logger.info(f"Checking file {settings_file}")
+        if not os.path.exists(settings_file):
+            continue
+
+        with open(settings_file, 'r') as fp:
+            data = json.load(fp)
+
+            try:
+                log_level = logging.getLevelName(data['logging']['default']['level'])
+                logger.setLevel(level=log_level)          
+                return
+            except:
+                pass
+             
+
 # -------------------------------------------------------------------------
 # RUN LUMAVIEWPRO APP
 # -------------------------------------------------------------------------
 class LumaViewProApp(App):
     def on_start(self):
+        load_log_level()
         logger.info('[LVP Main  ] LumaViewProApp.on_start()')
         lumaview.scope.xyhome()
         # if profiling:

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -3243,6 +3243,10 @@ class ProtocolSettings(CompositeCapture):
     def protocol_iterate(self, dt):
         logger.info('[LVP Main  ] ProtocolSettings.protocol_iterate()')
 
+        # Don't start the next scan if the current scan is in progress
+        if self.scan_in_progress:
+            return
+
         # Simplified variables
         start_t = self.start_t # start of cycle in seconds
         curr_t = time.time()   # current time in seconds

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -3172,13 +3172,14 @@ class ProtocolSettings(CompositeCapture):
                 self.autofocus_was_used = False
 
             self.scan_count += 1
-            self.scan_in_progress = False
+            
             logger.info('[LVP Main  ] Scan Complete')
             self.ids['run_scan_btn'].state = 'normal'
             self.ids['run_scan_btn'].text = 'Run One Scan'
 
             logger.info('[LVP Main  ] Clock.unschedule(self.scan_iterate)')
             Clock.unschedule(self.scan_iterate) # unschedule all copies of scan iterate
+            self.scan_in_progress = False
 
     # Run protocol without xy movement
     def run_stationary(self):

--- a/lvp_logger.py
+++ b/lvp_logger.py
@@ -40,11 +40,11 @@ lvp_logger.py configures a standard python logger for LumaViewPro.
 import logging
 from logging.handlers import RotatingFileHandler
 import os
-if not os.path.exists("logs/LVP_Log"):
-    os.makedirs("logs/LVP_Log")
+
+os.makedirs("logs/LVP_Log", exist_ok=True)
 
 # file to which messages are logged 
-LOG_FILE = 'logs/LVP_log/lumaviewpro.log'
+LOG_FILE = 'logs/LVP_Log/lumaviewpro.log'
 
 # CustomFormatter class enables change in log format depending on log level 
 class CustomFormatter(logging.Formatter):

--- a/lvp_logger.py
+++ b/lvp_logger.py
@@ -68,8 +68,8 @@ logger.setLevel(logging.INFO)
 
 # obtains name of the module (file) importing lvp_logger
 filename = '%s' % __file__
-file_handler = RotatingFileHandler(LOG_FILE, mode='a', maxBytes=1*1024*1024, 
-                                 backupCount=0, encoding=None, delay=False)
+file_handler = RotatingFileHandler(LOG_FILE, mode='a', maxBytes=5*1024*1024, 
+                                 backupCount=2, encoding=None, delay=False)
 # file_handler = logging.FileHandler(LOG_FILE)
 file_handler.setFormatter(CustomFormatter())
 logger.addHandler(file_handler)

--- a/lvp_logger.py
+++ b/lvp_logger.py
@@ -50,14 +50,14 @@ LOG_FILE = 'logs/LVP_Log/lumaviewpro.log'
 class CustomFormatter(logging.Formatter):
     # if level is DEBUG/WARNING/ERROR/CRITICAL, log the level, message, time, and filename
     def __init__(self, 
-                 fmt = '[%(levelname)s] %(asctime)s - %(filename)s - %(message)s', 
-                 datefmt ='%m/%d/%Y %I:%M:%S %p'):
+                 fmt = '[%(levelname)s] %(asctime)s.%(msecs)03d - %(filename)s - %(message)s', 
+                 datefmt ='%m/%d/%Y %H:%M:%S'):
         logging.Formatter.__init__(self, fmt, datefmt)
 
     def format(self, record):
-        if record.levelno == logging.INFO:
-            # if INFO level, only log the message
-            return record.getMessage()
+        # if record.levelno == logging.INFO:
+        #     # if INFO level, only log the message
+        #     return record.getMessage()
         return logging.Formatter.format(self, record)
 
 # ensures logger is specific to the file importing lvp_logger

--- a/modules/common_utils.py
+++ b/modules/common_utils.py
@@ -1,4 +1,6 @@
 
+import os
+import pathlib
 import re
 
 
@@ -40,6 +42,11 @@ def get_tile_label_from_name(name: str) -> str | None:
 def get_well_label_from_name(name: str) -> str | None:
     name = name.split('_')
 
+    # Handle case where channel name is parent folder and remov eit
+    split_name = os.path.split(name[0])
+    if len(split_name) == 2:
+        return split_name[1]
+
     return name[0]
 
 
@@ -51,10 +58,25 @@ def get_layer_from_name(name: str) -> str | None:
 
 
 def replace_layer_in_step_name(step_name: str, new_layer_name: str) -> str | None:
-    if is_custom_name(name=step_name):
+
+    # Extract basename in case we are handling protocol with separate folders per channel
+    base_name = os.path.basename(step_name)
+    if is_custom_name(name=base_name):
         return None
+
+    # This replaces the parent folder when using per-channel folders for protocol runs
+    split_name = list(os.path.split(step_name))
+    if len(split_name) == 2:
+        using_per_channel_folders = True
+    else:
+        using_per_channel_folders = False
     
+    if using_per_channel_folders:
+        split_name[0] = new_layer_name
+        step_name = str(pathlib.Path(split_name[0]) / split_name[1])
+
     step_name_segments = step_name.split('_')
+    
     step_name_segments[1] = new_layer_name
     return '_'.join(step_name_segments)
 

--- a/modules/composite_generation.py
+++ b/modules/composite_generation.py
@@ -51,6 +51,12 @@ class CompositeGeneration:
                 new_layer_name='Composite'
             )
 
+            # Create parent folder if needed
+            split_name = os.path.split(composite_filename)
+            if len(split_name) == 2:
+                composite_path = path / split_name[0]
+                pathlib.Path(composite_path).mkdir(parents=True, exist_ok=True)
+
             # Filter out non-fluorescence layers
             allowed_layers = common_utils.get_fluorescence_layers()
             composite_group = composite_group[composite_group['color'].isin(allowed_layers)]

--- a/modules/protocol_post_processing_helper.py
+++ b/modules/protocol_post_processing_helper.py
@@ -1,4 +1,5 @@
 
+import os
 import pathlib
 
 import pandas as pd
@@ -18,10 +19,10 @@ class ProtocolPostProcessingHelper:
 
     @staticmethod
     def _get_image_filenames_from_folder(path: pathlib.Path) -> list:
-        images = path.glob('*.tif[f]')
+        images = path.glob('**/*.tif[f]')
         image_names = []
         for image in images:
-            image_names.append(image.name)
+            image_names.append(os.path.relpath(image, path))
 
         return image_names
 

--- a/modules/stitcher.py
+++ b/modules/stitcher.py
@@ -89,7 +89,14 @@ class Stitcher:
             scan_count=row0['scan_count']
         )
 
-        return f"{name}_stitched.tiff"
+        outfile = f"{name}_stitched.tiff"
+
+        # Handle case of individual folders per channel
+        split_name = os.path.split(row0['filename'])
+        if len(split_name) == 2:
+            outfile = os.path.join(split_name[0], outfile)
+        
+        return outfile
 
 
     @staticmethod


### PR DESCRIPTION
Includes the following:
- Ability to save protocol captures in separate folders per channel
- Z-axis grease redistribution during protocol when using autofocus
- Fix log rotation and sizing
- Fix log output directory due to case inconsistency
- Update to prevent next protocol scan from starting if current scan is still in progress
- Add support for setting logging level in json config
- Configure max exposure value based on layer type
- Add support for engineering mode
- Add support for overlaying crosshairs on live image
- Add support for bullseye display in engineering mode
- Add support for image mean/stddev stats in engineering mode
- Add ability to disable image saving in engineering mode
- Update logging format to include millisecond resolution
- Adjust position of camera controls to be centered