### PR TITLE
Initialize Turret 1 Button Being Down

### DIFF
--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -419,6 +419,7 @@
 		ToggleButton:
 			id: turret_pos_1_btn
 			text: '1'
+			state: 'down'
             on_release: root.turret_select(1)
 		ToggleButton:
 			id: turret_pos_2_btn


### PR DESCRIPTION
The Lumascope starts with Turret 1 being selected (hardware-wise), so the UI should now reflect that Turret 1 is selected upon launch. Upon selecting another turret, the UI properly updates and deselects Turret 1.