### PR TITLE
Fix to ensure video capture duration is correct

### DIFF
--- a/lumaviewpro.kv
+++ b/lumaviewpro.kv
@@ -2336,7 +2336,7 @@
 				spacing: '5dp'
 
 				Label:
-					text: 'FPS'
+					text: 'Max FPS'
 					halign: 'left'
 					valign: 'middle'
 					font_size: '12sp'

--- a/modules/sequenced_capture_executor.py
+++ b/modules/sequenced_capture_executor.py
@@ -690,7 +690,7 @@ class SequencedCaptureExecutor:
                             image = image_utils.add_false_color(array=image, color=use_color)
 
                         image = np.flip(image, 0)
-                        video_images.append((image, datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]))
+                        video_images.append((image, datetime.datetime.now()))
                     
                     # Some process is slowing the video-process down (getting fewer frames than expected if delay of seconds_per_frame), so a shorter sleep time can be used
                     time.sleep(seconds_per_frame*0.9)

--- a/modules/sequenced_capture_executor.py
+++ b/modules/sequenced_capture_executor.py
@@ -666,15 +666,19 @@ class SequencedCaptureExecutor:
 
                 start_ts = time.time()
                 stop_ts = start_ts + duration_sec
+                expected_frames = fps * duration_sec
+                captured_frames = 0
                 seconds_per_frame = 1.0 / fps
 
-                while time.time() < stop_ts:
+                while time.time() < stop_ts or captured_frames < expected_frames:
                     if 'update_scope_display' in self._callbacks:
                         self._callbacks['update_scope_display']()
                         
                     # Currently only support 8-bit images for video
                     force_to_8bit = True
                     image = self._scope.get_image(force_to_8bit=force_to_8bit)
+
+                    captured_frames += 1
 
                     if type(image) == np.ndarray:
                         

--- a/modules/video_writer.py
+++ b/modules/video_writer.py
@@ -93,14 +93,17 @@ class VideoWriter:
         # )
 
 
-    def add_frame(self, image: np.ndarray):
+    def add_frame(self, image: np.ndarray, timestamp=None):
 
         # First frame initialization
         if self._video is None:
             self._init_video(image=image)
         
         if self._include_timestamp_overlay:
-            ts = self._get_timestamp_str()
+            if timestamp is not None:
+                ts = timestamp
+            else:
+                ts = self._get_timestamp_str()
             image = image_utils.add_timestamp(image=image, timestamp_str=ts)
         
         self._video.write(image)

--- a/modules/video_writer.py
+++ b/modules/video_writer.py
@@ -58,8 +58,11 @@ class VideoWriter:
     
 
     @staticmethod
-    def _get_timestamp_str():
-        ts = datetime.datetime.now()
+    def _get_timestamp_str(timestamp=None):
+        if timestamp is not None:
+            ts = timestamp
+        else:
+            ts = datetime.datetime.now()
         ts_str = ts.strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         return ts_str
 
@@ -101,7 +104,7 @@ class VideoWriter:
         
         if self._include_timestamp_overlay:
             if timestamp is not None:
-                ts = timestamp
+                ts = self._get_timestamp_str(timestamp)
             else:
                 ts = self._get_timestamp_str()
             image = image_utils.add_timestamp(image=image, timestamp_str=ts)


### PR DESCRIPTION
Adds a check to make sure the number of frames that were captured is the number that was expected. Tradeoff is that the step might take a little longer than the video duration (due to overhead or processing), but will ensure a video with the correct fps and duration.