### PR TITLE
Fix for multiple issues including LED quick turn off

### DIFF
--- a/lumascope_api.py
+++ b/lumascope_api.py
@@ -549,6 +549,7 @@ class Lumascope():
             sum_count: int = 1,
             sum_delay_s: float = 0,
             sum_iteration_callback = None,
+            turn_off_all_leds_after: bool = False,
         ):
 
         """CAMERA FUNCTIONS
@@ -563,6 +564,10 @@ class Lumascope():
             sum_delay_s=sum_delay_s,
             sum_iteration_callback=sum_iteration_callback,
         )
+
+        if True == turn_off_all_leds_after:
+            self.leds_off()
+
         if array is False:
             return 
         return self.save_image(array, save_folder, file_root, append, color, tail_id_mode, output_format=output_format, true_color=true_color)

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -453,6 +453,7 @@ def go_to_step(
     layer_obj.ids['sum_slider'].value = int(step["Sum"])
 
     # acquire type
+    settings[color]['acquire'] = step['Acquire']
     for acquire_sel in ('acquire_video', 'acquire_image', 'acquire_none'):  
         layer_obj.ids[acquire_sel].active = False
 
@@ -942,7 +943,7 @@ class ScopeDisplay(Image):
         
         if display_update_counter % 10 == 0:
             display_update_counter = 0
-            
+
             layer, layer_config = get_active_layer_config()
             if True == layer_config['auto_gain']:
                 actual_gain = lumaview.scope.camera.get_gain()
@@ -4393,7 +4394,6 @@ class ProtocolSettings(CompositeCapture):
         for layer, layer_config in layer_configs.items():
             if layer_config['acquire'] == None:
                 continue
-
 
             _ = self._protocol.insert_step(
                 step_name=None,

--- a/modules/sequenced_capture_executor.py
+++ b/modules/sequenced_capture_executor.py
@@ -819,6 +819,7 @@ class SequencedCaptureExecutor:
                     sum_count=sum_count,
                     sum_delay_s=step["Exposure"]/1000,
                     sum_iteration_callback=sum_iteration_callback,
+                    turn_off_all_leds_after=True,
                 )
         else:
             result = None


### PR DESCRIPTION
- Turn off LEDs quickly after image capture when running protocol or manual composite capture
- When using AGAE, disable gain and exposure sliders and update slider values with camera settings.
- When loading an existing protocol, set all layers to acquire = None, except for the first step in the layer.
- Fix bug for adding a protocol step to correctly add all selected layers.