### PR TITLE
Fix for initialization issue related to overriding settings

### DIFF
--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -5646,7 +5646,7 @@ class LayerControl(BoxLayout):
     
     def _init_ui(self, dt=0):
         if True == self.autogain_support:
-            self.update_auto_gain()
+            self.update_auto_gain(init=True)
         else:
             self.apply_settings()
 
@@ -5725,7 +5725,7 @@ class LayerControl(BoxLayout):
 
         self.apply_settings()
 
-    def update_auto_gain(self):
+    def update_auto_gain(self, init: bool = False):
         logger.info('[LVP Main  ] LayerControl.update_auto_gain()')
         if self.ids['auto_gain'].state == 'down':
             state = True
@@ -5739,7 +5739,9 @@ class LayerControl(BoxLayout):
         actual_gain = lumaview.scope.camera.get_gain()
         actual_exp = lumaview.scope.camera.get_exposure_t()
 
-        if False == state:
+        # If being called on program initialization, we don't want to
+        # inadvertantly load the settings from the scope hardware into the software maintained settings
+        if (False == init) and (False == state):
             settings[self.layer]['gain'] = actual_gain
             settings[self.layer]['exp'] = actual_exp
 


### PR DESCRIPTION
This is a fix for an issue that was introduced when adding readback support of auto-gain values from camera.  On initialization, if auto-gain was supported, the bug would cause the current camera gain/exposure to be readback from hardware and overwrite the `settings` value.  This fix prevents that overwriting from occurring during initialization procedures.