### PR TITLE
Update package dependencies associated with pyimagej

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,16 @@ numpy==1.26.4
 opencv-python==4.9.0.80
 pandas==2.2.1
 plyer==2.1.0
-pyimagej==1.4.1
 pypylon==3.0.1
 pyserial==3.5
 scikit-image==0.22.0
 scipy==1.12.0
 tifffile==2024.9.20
 userpaths==0.1.3
+xarray==2025.3.0
+
+# Packages related to Java support
+jgo==1.0.6
+JPype1==1.5.2
+pyimagej==1.6.0
+scyjava==1.10.2


### PR DESCRIPTION
Update package dependencies associated with JRE / pyimagej which were out of date.  This is in attempt to address intermittent crashing experienced related to https://github.com/EtalumaSupport/LumaViewPro/issues/422.  With the updated dependencies, so far unable to cause a crash again.