### PR TITLE
Fix for #563. Catches race condition where sequential capture executo…

### DIFF
--- a/modules/sequenced_capture_executor.py
+++ b/modules/sequenced_capture_executor.py
@@ -551,6 +551,9 @@ class SequencedCaptureExecutor:
         if not self._grease_redistribution_done:
             return
         
+        if self._protocol_ended.is_set() or not self._scan_in_progress.is_set():
+            return
+        
         if self._z_ui_update_func is not None:
             Clock.schedule_once(lambda dt: self._z_ui_update_func(float(step['Z'])), 0)
 


### PR DESCRIPTION
…r is in the middle of scan iteration call when the autofocus executor finishes.  The bug was causing the SeqCapExecutor to issue an errant final UI update to the autofocus UI slider. Z-axis was not actually moving though (and shouldn't be).