### PR TITLE
fix: convert cv2.imread BGR to RGB in VideoBuilder (#657 video side)

### DIFF
--- a/modules/video_builder.py
+++ b/modules/video_builder.py
@@ -214,6 +214,13 @@ class VideoBuilder(ProtocolPostProcessor):
                 logger.error(f"[{self._name}] Failed to read image: {image_path}")
                 continue
 
+            # cv2.imread returns BGR for 3-channel images regardless of source
+            # file format. VideoWriter expects RGB per the canonical save-path
+            # convention; without this conversion the false-colored blue
+            # channel saved to TIFF lands in the red channel of the mp4.
+            if image.ndim == 3:
+                image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
+
             # Timestamp overlay and 8-bit conversion handled by VideoWriter.add_frame()
             frame_ts = row['Timestamp'].to_pydatetime() if enable_timestamp_overlay else None
             video.add_frame(image=image, timestamp=frame_ts)

--- a/tests/test_video_builder.py
+++ b/tests/test_video_builder.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2023-2026 Etaluma, Inc. MIT License. See LICENSE file.
+"""#657 regression: VideoBuilder must feed RGB to VideoWriter.
+
+Setup:
+  - TIFFs on disk are saved in RGB ordering (canonical save-path convention
+    established by e2ef49e: add_false_color returns RGB; write_tiff stores
+    photometric=RGB).
+  - cv2.imread, used by VideoBuilder._create_video to read frames back,
+    always returns BGR for 3-channel images (OpenCV convention).
+  - VideoWriter expects RGB per the same canonical convention (PyAV uses
+    'rgb24'; cv2 fallback converts to BGR at its own boundary).
+
+Without a BGR->RGB conversion after cv2.imread, the blue channel of an
+RGB-saved frame lands in the red channel of the output mp4. That was #657's
+video-side symptom after the frame-side was fixed by e2ef49e.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+import tifffile
+
+# Heavy deps are mocked by tests/conftest.py at module-import time.
+
+
+@pytest.fixture
+def blue_rgb_frame(tmp_path):
+    """Write a single 16-bit TIFF with a known RGB blue value.
+
+    Saved layout: array of shape (H, W, 3) where index 0=Red, 1=Green, 2=Blue
+    (canonical save-path RGB ordering). All pixels have R=0, G=0, B=42000.
+    """
+    arr = np.zeros((4, 4, 3), dtype=np.uint16)
+    arr[:, :, 2] = 42000  # Blue at index 2 per RGB convention
+    file_loc = tmp_path / "frame_0001.tif"
+    tifffile.imwrite(str(file_loc), arr, photometric='rgb')
+    return file_loc
+
+
+class TestVideoBuilderBgrToRgb_657:
+    """#657 regression: video build must apply BGR->RGB after cv2.imread."""
+
+    def test_create_video_feeds_rgb_to_videowriter(self, blue_rgb_frame, tmp_path):
+        """End-to-end: a Blue-RGB TIFF on disk reaches VideoWriter.add_frame
+        as Blue-RGB (channel index 2 still holds the data), not BGR-flipped."""
+        from modules.video_builder import VideoBuilder
+
+        # Capture every image handed to VideoWriter.add_frame.
+        captured = []
+
+        class CaptureWriter:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def add_frame(self, image, timestamp=None):
+                captured.append(image.copy())
+
+            def finish(self):
+                pass
+
+        df = pd.DataFrame({
+            'Filepath': [blue_rgb_frame.name],
+            'Timestamp': [pd.Timestamp('2026-05-15 12:00:00')],
+            'Scan Count': [0],
+        })
+
+        builder = VideoBuilder.__new__(VideoBuilder)
+        builder._name = 'test_video_builder_657'
+
+        with patch('modules.video_writer.VideoWriter', CaptureWriter):
+            builder._create_video(
+                path=tmp_path,
+                df=df,
+                frames_per_sec=10,
+                enable_timestamp_overlay=False,
+                output_file_loc=Path('out.mp4'),
+            )
+
+        assert len(captured) == 1, "VideoWriter.add_frame should fire once per frame"
+        frame = captured[0]
+        assert frame.ndim == 3, "Color frame expected"
+        # If the BGR->RGB conversion is applied, blue stays at channel 2.
+        # If the conversion is missing, cv2.imread's BGR-return puts the blue
+        # data at channel 0 (red) and 42000 will appear there instead.
+        assert frame[0, 0, 2] == 42000, (
+            f"Blue channel should be at RGB index 2; got "
+            f"R={frame[0, 0, 0]} G={frame[0, 0, 1]} B={frame[0, 0, 2]}"
+        )
+        assert frame[0, 0, 0] == 0, "Red channel should be zero in a pure-Blue source"


### PR DESCRIPTION
## Summary

Closes the video-side recurrence of #657. Yesterday's \`e2ef49e\` fixed the frame side (TIFFs save correctly as RGB false-color); Chris confirmed frames are now blue but reports the mp4 from Create Video still comes out red. Root cause traced to \`modules/video_builder.py:212\` -- \`cv2.imread\` returns BGR for 3-channel images (OpenCV convention) and was being fed directly to \`VideoWriter.add_frame\` which expects RGB per the canonical save-path convention.

## Fix

\`cv2.cvtColor(BGR2RGB)\` after \`cv2.imread\` for 3-channel frames in the build loop.

## Cluster check (Rule 16)

6 \`cv2.imread\` sites surveyed in production code:

| Site | Status |
|---|---|
| \`modules/video_builder.py:212\` (Create Video frame loop) | **FIXED** |
| \`modules/video_builder.py:174\` (shape sample only) | safe (no color use) |
| \`modules/composite_generation.py:155\` + \`:172\` | BGR-consistent (paired cv2.cvtColor) |
| \`modules/stitcher.py:134\` | pending audit |
| \`modules/image_utils.py:94\` (generic file loader) | pending audit |

Other sites need the same triage; \`docs/AUDIT_COLOR_CONVENTION_2026-05-15.md\` (separate doc shell) schedules the comprehensive census per Rule 44.

## Regression test

\`tests/test_video_builder.py::TestVideoBuilderBgrToRgb_657\`:
- Writes a 4x4x3 uint16 TIFF with R=0 G=0 B=42000 (RGB ordering).
- Calls \`VideoBuilder._create_video\` with a captured-frame VideoWriter.
- Asserts the captured image is RGB-ordered (blue at channel index 2).

Without the fix, cv2.imread's BGR-return would put 42000 at channel 0 and the assertion would fail; with the fix, blue stays at channel 2.

## Test plan

- [x] New regression test passes (\`pytest tests/test_video_builder.py -q\` -> PASS).
- [ ] Bench validation by Chris on next \`4.0.0-wave7-decomp\` build.
- [ ] Audit (separate doc) for the remaining \`cv2.imread\` sites and the broader BGR/RGB convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)