### PR TITLE
ci: only re-flag OPEN issues for retriage (skip close-with-comment artifact)

### DIFF
--- a/.github/workflows/issue-label-lifecycle.yml
+++ b/.github/workflows/issue-label-lifecycle.yml
@@ -50,9 +50,16 @@ jobs:
   # awaiting-bench-data). There is new input to weigh, so the handled-state claim
   # is no longer trustworthy: strip whichever handled-state labels are present and
   # raise the retriage flag.
+  #
+  # Only OPEN issues qualify. A "Close with comment" on a handled issue fires this
+  # same issue_comment event, and without the open guard the closing comment
+  # (e.g. "fixed") re-applied "New data - needs retriage" on an issue that was
+  # closed in the same breath -- polluting the retriage queue with closed issues.
+  # A genuine reopen-with-new-data path reopens the issue first, so OPEN is right.
   handled-to-retriage:
     if: >-
       github.event_name == 'issue_comment' &&
+      github.event.issue.state == 'open' &&
       !contains(github.event.comment.body, '<!-- claude:annotation -->') &&
       (contains(github.event.issue.labels.*.name, 'Fixed Needs verification') ||
        contains(github.event.issue.labels.*.name, 'Analyzed') ||


### PR DESCRIPTION
## Problem
The `handled-to-retriage` job in `issue-label-lifecycle.yml` fires on any non-marker `issue_comment` on a handled issue, with **no open/closed check**. A "Close with comment" fires the same event, so a closing comment (e.g. the support account's "fixed") strips `Fixed Needs verification` and re-applies `New data - needs retriage` on an issue being closed in the same operation.

## Evidence
An audit of all 18 issues carrying `New data - needs retriage` found **all 18 were CLOSED**, and **17 of 18** had the label added by `github-actions[bot]` 5-15 seconds after the close event. The 18th (#559) was a genuine post-close comment, since resolved. The entire retriage queue was automation noise.

## Fix
Gate `handled-to-retriage` on `github.event.issue.state == 'open'`. A genuine reopen-with-new-data reopens the issue first, so OPEN is the correct gate. The 18 already-mislabeled closed issues were cleared separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)