### PR TITLE
added quick enhance workflow, tests, and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ reports_current_10x10/
 generated_tiles_current_10x10/
 results_current_10x10/
 actual_tile_data/
+recent_issue/

--- a/docs/QUICK_ENHANCE.md
+++ b/docs/QUICK_ENHANCE.md
@@ -1,0 +1,23 @@
+# Quick Enhance
+
+Quick Enhance creates a derived TIFF for visual inspection. It never changes the source image. Do not use derived files for quantitative analysis.
+
+## Use it
+
+1. Choose Image to inspect and save one image, or Choose Folder to save every supported image in that folder.
+2. Select a mode.
+3. Save Image or Save Folder. Use Show Output Folder when complete.
+
+Choose Image enables Before / After and Update Preview. A folder is a batch operation, so it has no single-image preview.
+
+## Modes
+
+- **Auto (Recommended)** — Detects each image independently. BF, phase, and darkfield use the gentle brightfield adjustment. Composite, fluorescence, and unknown images use neutral automatic contrast.
+- **Brightfield / Phase** — Forces the gentle brightfield adjustment (automatic contrast plus light brightening). Use when Auto cannot identify a BF, phase, or darkfield file.
+- **Contrast Only** — Applies automatic contrast only. Use when you do not want the brightfield adjustment.
+
+## Buttons
+
+- **Before / After** switches the single-image preview between the source and its enhanced version.
+- **Update Preview** redraws the single-image preview using the selected mode.
+- **Show Output Folder** opens the folder containing the most recently saved derived TIFFs.

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -369,6 +369,7 @@ from ui.post_processing import (
     CompositeGenControls,
     GraphingControls,
     PostProcessingAccordion,
+    QuickEnhanceControls,
     StitchControls,
     VideoCreationControls,
     ZProjectionControls,

--- a/modules/app_context.py
+++ b/modules/app_context.py
@@ -85,6 +85,7 @@ class AppContext:
     composite_gen_controls: object = None
     video_creation_controls: object = None
     zprojection_controls: object = None
+    quick_enhance_controls: object = None
     metrics_logger: object = None  # MetricsLogger (LVP-A-12)
     ui_listener_bridge: object = None  # UIListenerBridge (LVP-A-6)
 

--- a/modules/quick_enhance.py
+++ b/modules/quick_enhance.py
@@ -299,12 +299,18 @@ class QuickEnhancer:
                 significant_bits=significant_bits,
             )
             output_for_write = self.colorize_mono_for_visual_output(output, channel)
-            if source_path.suffix.lower() not in ('.tif', '.tiff') and output.ndim == 3:
+            if output_for_write.ndim == 3 and output_for_write.shape[2] == 4:
+                # The TIFF writer supports RGB samples, not RGBA. Alpha is a
+                # display-only component for these composite inputs, so retain
+                # the enhanced RGB data and preserve the Composite metadata.
+                output_for_write = output_for_write[..., :3]
+            if source_path.suffix.lower() not in ('.tif', '.tiff') and output_for_write.ndim == 3:
                 # cv2 loads PNG/JPEG in BGR(A), whereas TIFF metadata and the
-                # project's TIFF writer are RGB-native.
+                # project's TIFF writer are RGB-native. Convert the alpha-free
+                # display payload so a Composite PNG cannot reintroduce RGBA.
                 output_for_write = cv2.cvtColor(
-                    output,
-                    cv2.COLOR_BGRA2RGBA if output.shape[2] == 4 else cv2.COLOR_BGR2RGB,
+                    output_for_write,
+                    cv2.COLOR_BGR2RGB,
                 )
             image_utils.write_tiff(
                 data=output_for_write,

--- a/modules/quick_enhance.py
+++ b/modules/quick_enhance.py
@@ -1,0 +1,391 @@
+"""Deterministic, local image enhancements for visual inspection.
+
+Quick Enhance deliberately creates derived files only.  It is not a
+quantitative-processing path and must never be used by image acquisition or
+the live display worker.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import os
+import pathlib
+import re
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Callable
+
+import cv2
+import numpy as np
+
+from lvp_logger import logger
+from modules import common_utils, image_utils
+
+
+PIPELINE_VERSION = '1'
+QUANTITATIVE_USE_WARNING = (
+    'Quick Enhance is for visual inspection and derived exports. '
+    'Use raw images for quantitative analysis.'
+)
+SUPPORTED_SUFFIXES = frozenset({'.tif', '.tiff', '.png', '.jpg', '.jpeg', '.bmp'})
+MAX_IMAGE_PIXELS = 100_000_000
+
+
+@dataclass(frozen=True)
+class QuickEnhanceSettings:
+    """Conservative settings for a deterministic visual enhancement."""
+
+    preset: str = 'Auto (Recommended)'
+    low_percentile: float = 1.0
+    high_percentile: float = 99.0
+    gamma: float = 1.0
+    background_enabled: bool = False
+    background_sigma: float = 24.0
+    denoise_enabled: bool = False
+    denoise_kernel_size: int = 3
+
+    @classmethod
+    def for_preset(cls, preset: str) -> 'QuickEnhanceSettings':
+        presets = {
+            'Auto (Recommended)': cls(preset='Auto (Recommended)'),
+            'Brightfield / Phase': cls(preset='Brightfield / Phase', gamma=0.9),
+            'Contrast Only': cls(preset='Contrast Only'),
+        }
+        try:
+            return presets[preset]
+        except KeyError as exc:
+            raise ValueError(f'Unknown Quick Enhance preset: {preset}') from exc
+
+
+class QuickEnhancer:
+    """Apply and export a safe enhancement recipe without GUI dependencies."""
+
+    def validate(
+        self,
+        settings: QuickEnhanceSettings,
+        dtype: np.dtype,
+        significant_bits: int,
+    ) -> list[str]:
+        errors = []
+        dtype = np.dtype(dtype)
+        if dtype not in (np.dtype(np.uint8), np.dtype(np.uint16)):
+            errors.append('Quick Enhance supports uint8 and uint16 images only.')
+        container_bits = dtype.itemsize * 8
+        if not isinstance(significant_bits, (int, np.integer)) or not 1 <= significant_bits <= container_bits:
+            errors.append(f'Significant bits must be between 1 and {container_bits}.')
+        if not 0 <= settings.low_percentile < settings.high_percentile <= 100:
+            errors.append('Low percentile must be below high percentile, within 0 to 100.')
+        if not 0.5 <= settings.gamma <= 2.0:
+            errors.append('Gamma must be between 0.5 and 2.0.')
+        if not 1.0 <= settings.background_sigma <= 100.0:
+            errors.append('Background radius must be between 1 and 100 pixels.')
+        if settings.denoise_kernel_size not in (3, 5, 7):
+            errors.append('Denoise kernel must be 3, 5, or 7 pixels.')
+        return errors
+
+    def settings_for_source(
+        self,
+        source_path: str | pathlib.Path,
+        settings: QuickEnhanceSettings,
+    ) -> tuple[QuickEnhanceSettings, str]:
+        """Resolve Auto per file using acquisition metadata, never pixel guesses."""
+        if settings.preset != 'Auto (Recommended)':
+            return settings, f'{settings.preset} selected.'
+        source_path = pathlib.Path(source_path)
+        channel = self._source_channel(source_path)
+        if channel in common_utils.get_transmitted_layers():
+            return (
+                QuickEnhanceSettings.for_preset('Brightfield / Phase'),
+                f'Detected transmitted channel: {channel}.',
+            )
+        if channel == 'Composite':
+            return QuickEnhanceSettings.for_preset('Auto (Recommended)'), 'Detected Composite TIFF.'
+        if channel in common_utils.get_image_layers():
+            return QuickEnhanceSettings.for_preset('Auto (Recommended)'), f'Detected fluorescence channel: {channel}.'
+        return QuickEnhanceSettings.for_preset('Auto (Recommended)'), 'Image type unknown; using neutral auto levels.'
+
+    @staticmethod
+    def _source_channel(source_path: pathlib.Path) -> str | None:
+        metadata = image_utils.read_postproc_input_metadata(source_path) or {}
+        channel = metadata.get('channel')
+        if isinstance(channel, str) and channel:
+            return channel
+        # Some ImageJ-style monochrome TIFFs do not round-trip the channel
+        # field through read_postproc_input_metadata. LVP names include the
+        # layer as a token, so use that explicit label—not pixel appearance.
+        tokens = {token.upper() for token in re.split(r'[^A-Za-z0-9]+', source_path.stem)}
+        channel_by_token = {
+            'BF': 'BF',
+            'PC': 'PC',
+            'DF': 'DF',
+            'BLUE': 'Blue',
+            'GREEN': 'Green',
+            'RED': 'Red',
+            'LUMI': 'Lumi',
+            'COMPOSITE': 'Composite',
+        }
+        for token, label in channel_by_token.items():
+            if token in tokens:
+                return label
+        return None
+
+    @staticmethod
+    def colorize_mono_for_visual_output(image: np.ndarray, channel: str | None) -> np.ndarray:
+        """Return RGB false color for a mono fluorescence derived image.
+
+        Quick Enhance is a visual-export path. It retains transmitted-light
+        and unknown mono images as mono, while recognized fluorescence layers
+        receive their established display color only in the derived output.
+        """
+        if image.ndim == 2 and channel in common_utils.get_image_layers():
+            return image_utils.mono_to_rgb_falsecolor(image, channel)
+        return image
+
+    def apply(
+        self,
+        image: np.ndarray,
+        settings: QuickEnhanceSettings,
+        significant_bits: int,
+    ) -> np.ndarray:
+        """Return an enhanced copy at the source dtype and payload range."""
+        if image.size == 0:
+            raise ValueError('Quick Enhance cannot process an empty image.')
+        is_mono = image.ndim == 2
+        is_color = image.ndim == 3 and image.shape[2] in (3, 4)
+        if not (is_mono or is_color):
+            raise ValueError('Quick Enhance supports monochrome, RGB, and RGBA images only.')
+        if image.size > MAX_IMAGE_PIXELS:
+            raise MemoryError(
+                'Image is too large for Quick Enhance. Export a smaller region or use raw data.'
+            )
+        errors = self.validate(settings, image.dtype, significant_bits)
+        if errors:
+            raise ValueError(f'Invalid Quick Enhance settings: {" ".join(errors)}')
+
+        source_max = float((1 << int(significant_bits)) - 1)
+        # Work in float so background subtraction cannot wrap unsigned values.
+        # RGB/RGBA receives one shared levels/gamma curve derived from mean
+        # luminance. That keeps channel relationships predictable instead of
+        # independently stretching the component channels into a new composite.
+        work = np.clip(image.astype(np.float32, copy=False), 0.0, source_max) / source_max
+        channels = work if is_mono else work[..., :3].copy()
+        if not np.isfinite(work).all():
+            channels = np.nan_to_num(channels, nan=0.0, posinf=1.0, neginf=0.0)
+
+        if settings.background_enabled and min(image.shape) >= 3:
+            background = cv2.GaussianBlur(
+                channels,
+                (0, 0),
+                sigmaX=float(settings.background_sigma),
+                sigmaY=float(settings.background_sigma),
+                borderType=cv2.BORDER_REPLICATE,
+            )
+            # Keep a conservative low background pedestal; this avoids an
+            # all-black result while removing large-scale uneven illumination.
+            pedestal = np.percentile(background, 5.0, axis=(0, 1), keepdims=True)
+            channels = np.clip(channels - background + pedestal, 0.0, 1.0)
+
+        if settings.denoise_enabled and min(image.shape) >= settings.denoise_kernel_size:
+            channels = cv2.medianBlur(channels, int(settings.denoise_kernel_size))
+
+        levels_source = channels if is_mono else channels.mean(axis=2)
+        finite = levels_source[np.isfinite(levels_source)]
+        if finite.size == 0:
+            return image.copy()
+        black, white = np.percentile(
+            finite, (float(settings.low_percentile), float(settings.high_percentile))
+        )
+        if white <= black:
+            # A uniform image has no meaningful levels to stretch.  Returning
+            # a copy avoids inventing contrast (or changing it via gamma).
+            return image.copy()
+        channels = np.clip((channels - black) / (white - black), 0.0, 1.0)
+        if settings.gamma != 1.0:
+            channels = np.power(channels, float(settings.gamma), dtype=np.float32)
+
+        restored = image.copy()
+        enhanced_channels = np.rint(np.clip(channels, 0.0, 1.0) * source_max).astype(
+            image.dtype, copy=False
+        )
+        if is_mono:
+            return enhanced_channels
+        restored[..., :3] = enhanced_channels
+        return restored
+
+    def preview(
+        self,
+        image: np.ndarray,
+        settings: QuickEnhanceSettings,
+        significant_bits: int,
+        max_dimension: int = 1200,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return 8-bit before/after display arrays; intended for a worker task."""
+        preview_source = self._downsample(image, max_dimension)
+        preview_after = self.apply(preview_source, settings, significant_bits)
+        return (
+            image_utils.convert_to_8bit(preview_source, significant_bits),
+            image_utils.convert_to_8bit(preview_after, significant_bits),
+        )
+
+    @staticmethod
+    def _downsample(image: np.ndarray, max_dimension: int) -> np.ndarray:
+        height, width = image.shape[:2]
+        current = max(height, width)
+        if current <= max_dimension:
+            return image.copy()
+        scale = max_dimension / current
+        return cv2.resize(
+            image,
+            (max(1, round(width * scale)), max(1, round(height * scale))),
+            interpolation=cv2.INTER_AREA,
+        )
+
+    def recipe_dict(
+        self,
+        *,
+        source_path: pathlib.Path,
+        output_path: pathlib.Path,
+        settings: QuickEnhanceSettings,
+        input_dtype: np.dtype,
+        output_dtype: np.dtype,
+        significant_bits: int,
+    ) -> dict:
+        return {
+            'source_filename': source_path.name,
+            'derived_filename': output_path.name,
+            'pipeline': 'Quick Enhance',
+            'pipeline_version': PIPELINE_VERSION,
+            'timestamp': datetime.datetime.now().astimezone().isoformat(timespec='seconds'),
+            'input_dtype': np.dtype(input_dtype).name,
+            'output_dtype': np.dtype(output_dtype).name,
+            'significant_bits': int(significant_bits),
+            'operations': {
+                'auto_levels': {
+                    'enabled': True,
+                    'low_percentile': settings.low_percentile,
+                    'high_percentile': settings.high_percentile,
+                },
+                'gamma': {'enabled': settings.gamma != 1.0, 'value': settings.gamma},
+                'background_correction': {
+                    'enabled': settings.background_enabled,
+                    'sigma': settings.background_sigma,
+                },
+                'denoise': {
+                    'enabled': settings.denoise_enabled,
+                    'kernel_size': settings.denoise_kernel_size,
+                },
+            },
+            'settings': asdict(settings),
+            'quantitative_use_warning': QUANTITATIVE_USE_WARNING,
+        }
+
+    def export_file(self, source_path: str | pathlib.Path, settings: QuickEnhanceSettings) -> dict:
+        source_path = pathlib.Path(source_path)
+        settings, _ = self.settings_for_source(source_path, settings)
+        image, significant_bits = image_utils.load_pixels(source_path)
+        output = self.apply(image, settings, significant_bits)
+        output_path = self._next_output_path(source_path)
+        recipe_path = output_path.with_suffix('.recipe.json')
+
+        temp_output = output_path.with_name(f'.{output_path.stem}.{uuid.uuid4().hex}.tmp.tif')
+        temp_recipe = recipe_path.with_name(f'.{recipe_path.name}.{uuid.uuid4().hex}.tmp')
+        try:
+            source_metadata = image_utils.read_postproc_input_metadata(source_path) or {}
+            channel = str(source_metadata.get('channel') or self._source_channel(source_path) or 'BF')
+            metadata = image_utils.build_postproc_output_metadata(
+                input_path=source_path,
+                channel=channel,
+                significant_bits=significant_bits,
+            )
+            output_for_write = self.colorize_mono_for_visual_output(output, channel)
+            if source_path.suffix.lower() not in ('.tif', '.tiff') and output.ndim == 3:
+                # cv2 loads PNG/JPEG in BGR(A), whereas TIFF metadata and the
+                # project's TIFF writer are RGB-native.
+                output_for_write = cv2.cvtColor(
+                    output,
+                    cv2.COLOR_BGRA2RGBA if output.shape[2] == 4 else cv2.COLOR_BGR2RGB,
+                )
+            image_utils.write_tiff(
+                data=output_for_write,
+                file_loc=temp_output,
+                metadata=metadata,
+                ome=False,
+                color=channel,
+                significant_bits=significant_bits,
+                save_encoding='right_aligned',
+            )
+            recipe = self.recipe_dict(
+                source_path=source_path,
+                output_path=output_path,
+                settings=settings,
+                input_dtype=image.dtype,
+                output_dtype=output.dtype,
+                significant_bits=significant_bits,
+            )
+            temp_recipe.write_text(json.dumps(recipe, indent=2), encoding='utf-8')
+            os.replace(temp_recipe, recipe_path)
+            os.replace(temp_output, output_path)
+        except (OSError, ValueError, cv2.error, MemoryError):
+            for temporary in (temp_output, temp_recipe):
+                try:
+                    temporary.unlink(missing_ok=True)
+                except OSError:
+                    logger.warning('[QuickEnhance] Could not remove temporary file %s', temporary)
+            raise
+
+        return {'source_path': source_path, 'output_path': output_path, 'recipe_path': recipe_path}
+
+    def export_folder(
+        self,
+        folder: str | pathlib.Path,
+        settings: QuickEnhanceSettings,
+        progress_callback: Callable[[int, int, pathlib.Path], None] | None = None,
+    ) -> dict:
+        folder = pathlib.Path(folder)
+        files = sorted(
+            path
+            for path in folder.iterdir()
+            if path.is_file() and path.suffix.lower() in SUPPORTED_SUFFIXES
+            and '_enhanced' not in path.stem.lower()
+        )
+        created = []
+        skipped = []
+        total = len(files)
+        for completed, source_path in enumerate(files, start=1):
+            try:
+                created.append(self.export_file(source_path, settings))
+            except (OSError, ValueError, cv2.error, MemoryError) as exc:
+                logger.warning('[QuickEnhance] Skipping %s: %s', source_path, exc, exc_info=True)
+                skipped.append({'source_path': source_path, 'error': str(exc)})
+            if progress_callback is not None:
+                progress_callback(completed, total, source_path)
+        return {
+            'status': True,
+            'created_count': len(created),
+            'created': created,
+            'skipped': skipped,
+            'total': total,
+        }
+
+    @staticmethod
+    def output_folder(result: dict) -> pathlib.Path | None:
+        """Return the common derived-output folder from a completed export."""
+        created = result.get('created') or []
+        if not created:
+            return None
+        output_path = created[0].get('output_path')
+        return pathlib.Path(output_path).parent if output_path is not None else None
+
+    @staticmethod
+    def _next_output_path(source_path: pathlib.Path) -> pathlib.Path:
+        base = source_path.with_name(f'{source_path.stem}_enhanced.tif')
+        if not base.exists():
+            return base
+        for index in range(2, 10_002):
+            candidate = source_path.with_name(f'{source_path.stem}_enhanced_{index}.tif')
+            if not candidate.exists():
+                return candidate
+        raise FileExistsError(
+            f'Could not choose a derived filename for {source_path.name}: too many existing exports.'
+        )

--- a/tests/test_image_to_texture_depth_guard.py
+++ b/tests/test_image_to_texture_depth_guard.py
@@ -34,3 +34,13 @@ def test_uint8_payload_clears_guard():
     # 8-bit input passes the dtype guard; the downstream blit is mocked Kivy.
     result = image_to_texture(np.zeros((4, 4), dtype=np.uint8))
     assert result is not None
+
+
+def test_rgba_payload_is_converted_to_a_texture_without_grayscale_conversion():
+    rgba = np.zeros((4, 4, 4), dtype=np.uint8)
+    rgba[..., 1] = 255
+    rgba[..., 3] = 255
+
+    result = image_to_texture(rgba)
+
+    assert result is not None

--- a/tests/test_quick_enhance.py
+++ b/tests/test_quick_enhance.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import json
+import ast
+import pathlib
+
+import cv2
+import numpy as np
+import pytest
+
+from modules import image_utils
+from modules.quick_enhance import QuickEnhanceSettings, QuickEnhancer
+
+
+def _metadata(significant_bits: int, channel: str = 'Green') -> dict:
+    return {
+        'pixel_size_um': 1.0,
+        'channel': channel,
+        'objective': '10x',
+        'exposure_time_ms': 1.0,
+        'gain_db': 0.0,
+        'illumination_ma': 1.0,
+        'z_pos_um': 0.0,
+        'plate_pos_mm': {'x': 0.0, 'y': 0.0},
+        'datetime': '2026:07:17 00:00:00',
+        'significant_bits': significant_bits,
+    }
+
+
+def _write_source(path, data: np.ndarray, significant_bits: int, channel: str = 'Green') -> None:
+    image_utils.write_tiff(
+        data=data,
+        file_loc=path,
+        metadata=_metadata(significant_bits, channel),
+        ome=False,
+        color=channel,
+        significant_bits=significant_bits,
+        save_encoding='right_aligned',
+    )
+
+
+@pytest.mark.parametrize(
+    ('image', 'significant_bits', 'maximum'),
+    [
+        (np.arange(256, dtype=np.uint8).reshape(16, 16), 8, 255),
+        (np.linspace(0, 4095, 256, dtype=np.uint16).reshape(16, 16), 12, 4095),
+        (np.linspace(0, 65535, 256, dtype=np.uint16).reshape(16, 16), 16, 65535),
+    ],
+)
+def test_apply_preserves_source_dtype_range_and_input(image, significant_bits, maximum):
+    source = image.copy()
+    result = QuickEnhancer().apply(image, QuickEnhanceSettings(), significant_bits)
+
+    assert np.array_equal(image, source)
+    assert result.dtype == image.dtype
+    assert result.shape == image.shape
+    assert int(result.min()) >= 0
+    assert int(result.max()) <= maximum
+
+
+def test_uniform_image_is_stable_and_does_not_divide_by_zero():
+    image = np.full((12, 12), 1000, dtype=np.uint16)
+    result = QuickEnhancer().apply(
+        image, QuickEnhanceSettings.for_preset('Brightfield / Phase'), 12
+    )
+
+    assert np.array_equal(result, image)
+
+
+def test_rgb_images_use_one_shared_tone_curve_without_changing_shape_or_dtype():
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+    image[..., 0] = np.arange(16, dtype=np.uint8)[:, None] * 8
+    image[..., 1] = 100
+    image[..., 2] = 200
+    source = image.copy()
+
+    result = QuickEnhancer().apply(image, QuickEnhanceSettings(), 8)
+
+    assert np.array_equal(image, source)
+    assert result.shape == image.shape
+    assert result.dtype == np.uint8
+    assert int(result.min()) >= 0
+    assert int(result.max()) <= 255
+
+
+@pytest.mark.parametrize('suffix', ('.png', '.jpg'))
+def test_png_and_jpeg_load_preview_and_export_as_derived_tiff(tmp_path, suffix):
+    source = tmp_path / f'color{suffix}'
+    image = np.zeros((24, 32, 3), dtype=np.uint8)
+    image[..., 0] = 30
+    image[..., 1] = 120
+    image[..., 2] = 220
+    assert cv2.imwrite(str(source), image)
+
+    loaded, significant_bits = image_utils.load_pixels(source)
+    before, after = QuickEnhancer().preview(loaded, QuickEnhanceSettings(), significant_bits)
+    exported = QuickEnhancer().export_file(source, QuickEnhanceSettings())
+
+    assert before.shape == loaded.shape
+    assert after.shape == loaded.shape
+    assert exported['output_path'].suffix == '.tif'
+    assert exported['output_path'].exists()
+
+
+def test_invalid_settings_are_rejected_before_processing():
+    settings = QuickEnhanceSettings(low_percentile=99, high_percentile=1, gamma=3.0)
+    errors = QuickEnhancer().validate(settings, np.dtype(np.uint16), 12)
+
+    assert any('percentile' in error.lower() for error in errors)
+    assert any('gamma' in error.lower() for error in errors)
+    with pytest.raises(ValueError, match='Invalid Quick Enhance settings'):
+        QuickEnhancer().apply(np.ones((4, 4), dtype=np.uint16), settings, 12)
+
+
+def test_presets_are_stable_and_safe():
+    automatic = QuickEnhanceSettings.for_preset('Auto (Recommended)')
+    brightfield = QuickEnhanceSettings.for_preset('Brightfield / Phase')
+    contrast_only = QuickEnhanceSettings.for_preset('Contrast Only')
+
+    assert automatic.background_enabled is False
+    assert automatic.denoise_enabled is False
+    assert automatic.gamma == 1.0
+    assert brightfield.gamma == 0.9
+    assert contrast_only.gamma == 1.0
+    with pytest.raises(ValueError, match='Unknown Quick Enhance preset'):
+        QuickEnhanceSettings.for_preset('Custom')
+
+
+def test_auto_detects_transmitted_bf_from_tiff_name_when_metadata_is_unavailable(tmp_path):
+    source = tmp_path / 'scan_BF.tif'
+    _write_source(source, np.arange(64, dtype=np.uint16).reshape(8, 8), 12, channel='BF')
+
+    settings, description = QuickEnhancer().settings_for_source(
+        source, QuickEnhanceSettings.for_preset('Auto (Recommended)')
+    )
+
+    assert settings.preset == 'Brightfield / Phase'
+    assert settings.gamma == 0.9
+    assert 'BF' in description
+
+
+def test_auto_uses_neutral_levels_for_composite_and_unknown_images(tmp_path):
+    composite = tmp_path / 'composite.tif'
+    _write_source(composite, np.zeros((8, 8, 3), dtype=np.uint16), 12, channel='Composite')
+    unknown = tmp_path / 'untagged.png'
+    assert cv2.imwrite(str(unknown), np.zeros((8, 8, 3), dtype=np.uint8))
+    auto = QuickEnhanceSettings.for_preset('Auto (Recommended)')
+
+    composite_settings, composite_description = QuickEnhancer().settings_for_source(composite, auto)
+    unknown_settings, unknown_description = QuickEnhancer().settings_for_source(unknown, auto)
+
+    assert composite_settings.preset == 'Auto (Recommended)'
+    assert 'Composite' in composite_description
+    assert unknown_settings.preset == 'Auto (Recommended)'
+    assert 'neutral' in unknown_description
+
+
+def test_background_correction_never_wraps_unsigned_values():
+    image = np.zeros((64, 64), dtype=np.uint16)
+    image[:, 32:] = 100
+    image[20:30, 20:30] = 1000
+    settings = QuickEnhanceSettings(background_enabled=True, background_sigma=5.0)
+
+    result = QuickEnhancer().apply(image, settings, 12)
+
+    assert result.dtype == np.uint16
+    assert int(result.min()) >= 0
+    assert int(result.max()) <= 4095
+
+
+def test_tiny_images_with_denoise_are_safe():
+    image = np.array([[1]], dtype=np.uint8)
+    settings = QuickEnhanceSettings(denoise_enabled=True, denoise_kernel_size=3)
+
+    result = QuickEnhancer().apply(image, settings, 8)
+
+    assert np.array_equal(result, image)
+
+
+def test_recipe_has_required_provenance_and_quantitative_warning(tmp_path):
+    source = tmp_path / 'source.tif'
+    _write_source(source, np.arange(64, dtype=np.uint16).reshape(8, 8), 12)
+
+    recipe = QuickEnhancer().recipe_dict(
+        source_path=source,
+        output_path=tmp_path / 'source_enhanced.tif',
+        settings=QuickEnhanceSettings(),
+        input_dtype=np.dtype(np.uint16),
+        output_dtype=np.dtype(np.uint16),
+        significant_bits=12,
+    )
+
+    assert recipe['source_filename'] == 'source.tif'
+    assert recipe['pipeline_version']
+    assert recipe['quantitative_use_warning']
+    assert recipe['input_dtype'] == 'uint16'
+    assert recipe['operations']['auto_levels']['enabled'] is True
+
+
+def test_export_preserves_tiff_depth_writes_recipe_and_never_overwrites(tmp_path):
+    source = tmp_path / 'original.tif'
+    source_data = np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8)
+    _write_source(source, source_data, 12)
+    original_bytes = source.read_bytes()
+    enhancer = QuickEnhancer()
+
+    first = enhancer.export_file(source, QuickEnhanceSettings())
+    second = enhancer.export_file(source, QuickEnhanceSettings())
+
+    assert source.read_bytes() == original_bytes
+    assert first['output_path'].name == 'original_enhanced.tif'
+    assert second['output_path'].name == 'original_enhanced_2.tif'
+    out, significant_bits = image_utils.load_pixels(first['output_path'])
+    assert out.dtype == np.uint16
+    assert significant_bits == 12
+    recipe_path = first['output_path'].with_suffix('.recipe.json')
+    assert recipe_path.exists()
+    assert json.loads(recipe_path.read_text())['source_filename'] == 'original.tif'
+
+
+def test_brightfield_tiff_stays_monochrome_and_preserves_payload_depth(tmp_path):
+    source = tmp_path / 'bf.tif'
+    source_data = np.linspace(0, 4095, 256, dtype=np.uint16).reshape(16, 16)
+    _write_source(source, source_data, 12, channel='BF')
+
+    exported = QuickEnhancer().export_file(
+        source, QuickEnhanceSettings.for_preset('Brightfield / Phase')
+    )
+    output, significant_bits = image_utils.load_pixels(exported['output_path'])
+
+    assert output.ndim == 2
+    assert output.dtype == np.uint16
+    assert significant_bits == 12
+
+
+def test_composite_tiff_stays_rgb_and_retains_composite_channel_metadata(tmp_path):
+    source = tmp_path / 'composite.tif'
+    source_data = np.zeros((16, 16, 3), dtype=np.uint16)
+    source_data[..., 0] = 4095
+    source_data[..., 1] = np.arange(16, dtype=np.uint16)[:, None] * 200
+    source_data[..., 2] = 1000
+    _write_source(source, source_data, 12, channel='Composite')
+
+    exported = QuickEnhancer().export_file(source, QuickEnhanceSettings())
+    output, significant_bits = image_utils.load_pixels(exported['output_path'])
+    metadata = image_utils.read_postproc_input_metadata(exported['output_path'])
+
+    assert output.shape == source_data.shape
+    assert output.dtype == np.uint16
+    assert significant_bits == 12
+    assert metadata['channel'] == 'Composite'
+
+
+@pytest.mark.parametrize(
+    ('channel', 'color_index'),
+    [('Red', 0), ('Green', 1), ('Blue', 2)],
+)
+def test_fluorescence_mono_output_is_false_colored_without_changing_bf_rules(channel, color_index):
+    enhancer = QuickEnhancer()
+    mono = np.arange(64, dtype=np.uint16).reshape(8, 8)
+
+    colored = enhancer.colorize_mono_for_visual_output(mono, channel)
+    grayscale_bf = enhancer.colorize_mono_for_visual_output(mono, 'BF')
+
+    assert colored.shape == (8, 8, 3)
+    assert np.array_equal(colored[..., color_index], mono)
+    assert all(not colored[..., index].any() for index in range(3) if index != color_index)
+    assert grayscale_bf.ndim == 2
+
+
+def test_green_auto_export_is_rgb_and_a_second_run_keeps_green_detection(tmp_path):
+    source = tmp_path / 'green_sample.tiff'
+    source_data = np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8)
+    _write_source(source, source_data, 12, channel='Green')
+    enhancer = QuickEnhancer()
+
+    first = enhancer.export_file(source, QuickEnhanceSettings.for_preset('Auto (Recommended)'))
+    output, significant_bits = image_utils.load_pixels(
+        first['output_path'], collapse_legacy_false_color=False
+    )
+    settings, detection = enhancer.settings_for_source(
+        first['output_path'], QuickEnhanceSettings.for_preset('Auto (Recommended)')
+    )
+
+    assert output.shape == (8, 8, 3)
+    assert output.dtype == np.uint16
+    assert significant_bits == 12
+    assert output[..., 1].any()
+    assert not output[..., 0].any()
+    assert not output[..., 2].any()
+    assert settings.preset == 'Auto (Recommended)'
+    assert 'Green' in detection
+
+
+def test_folder_batch_skips_unreadable_file_and_continues(tmp_path):
+    _write_source(
+        tmp_path / 'valid.tif', np.arange(64, dtype=np.uint16).reshape(8, 8), significant_bits=12
+    )
+    (tmp_path / 'bad.tif').write_bytes(b'not a tiff')
+    progress = []
+
+    result = QuickEnhancer().export_folder(
+        tmp_path,
+        QuickEnhanceSettings(),
+        progress_callback=lambda completed, total, path: progress.append((completed, total, path.name)),
+    )
+
+    assert result['status'] is True
+    assert result['created_count'] == 1
+    assert len(result['skipped']) == 1
+    assert [(completed, total) for completed, total, _ in progress] == [(1, 2), (2, 2)]
+    assert {name for _, _, name in progress} == {'valid.tif', 'bad.tif'}
+    assert (tmp_path / 'valid_enhanced.tif').exists()
+
+
+def test_mixed_folder_exports_bf_composite_png_jpeg_and_skips_bad_or_derived_files(tmp_path):
+    bf = tmp_path / 'bf.tif'
+    composite = tmp_path / 'composite.tif'
+    _write_source(
+        bf, np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8), 12, channel='BF'
+    )
+    composite_pixels = np.zeros((8, 8, 3), dtype=np.uint16)
+    composite_pixels[..., 0] = 4095
+    composite_pixels[..., 1] = 1200
+    _write_source(composite, composite_pixels, 12, channel='Composite')
+    png = tmp_path / 'share.png'
+    jpeg = tmp_path / 'share.jpg'
+    color = np.full((8, 8, 3), (20, 100, 220), dtype=np.uint8)
+    assert cv2.imwrite(str(png), color)
+    assert cv2.imwrite(str(jpeg), color)
+    bad = tmp_path / 'bad.tif'
+    bad.write_bytes(b'not an image')
+    existing_derived = tmp_path / 'old_enhanced.tif'
+    _write_source(existing_derived, np.ones((8, 8), dtype=np.uint16), 12, channel='BF')
+    original_bytes = {path: path.read_bytes() for path in (bf, composite, png, jpeg, bad, existing_derived)}
+    progress = []
+
+    result = QuickEnhancer().export_folder(
+        tmp_path,
+        QuickEnhanceSettings(),
+        progress_callback=lambda completed, total, path: progress.append((completed, total, path.name)),
+    )
+
+    assert result['total'] == 5
+    assert result['created_count'] == 4
+    assert [entry['source_path'].name for entry in result['skipped']] == ['bad.tif']
+    assert [(completed, total) for completed, total, _ in progress] == [
+        (1, 5), (2, 5), (3, 5), (4, 5), (5, 5)
+    ]
+    assert all(path.read_bytes() == original for path, original in original_bytes.items())
+    assert (tmp_path / 'bf_enhanced.tif').exists()
+    assert (tmp_path / 'composite_enhanced.tif').exists()
+    assert (tmp_path / 'share_enhanced.tif').exists()
+    assert (tmp_path / 'share_enhanced_2.tif').exists()
+
+
+def test_output_folder_is_reported_from_a_completed_export(tmp_path):
+    completed = {
+        'created': [
+            {
+                'output_path': tmp_path / 'source_enhanced.tif',
+            }
+        ]
+    }
+
+    assert QuickEnhancer.output_folder(completed) == tmp_path
+    assert QuickEnhancer.output_folder({'created': []}) is None
+
+
+def test_ui_export_callback_restores_controls_on_every_terminal_path():
+    """The popup wrapper binds ``done`` and failure must clear ``busy``."""
+    source = (pathlib.Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text()
+    tree = ast.parse(source)
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == 'QuickEnhanceControls')
+    assert any(
+        isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id == 'done' for target in node.targets)
+        for node in cls.body
+    )
+    callback = next(
+        node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == '_export_callback'
+    )
+    callback_source = ast.get_source_segment(source, callback)
+    assert 'self.busy = False' in callback_source
+    assert 'self._export_inflight = False' in callback_source
+
+
+def test_refresh_preview_requests_the_rebuilding_status():
+    source = (pathlib.Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text()
+    tree = ast.parse(source)
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == 'QuickEnhanceControls')
+    refresh = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == 'refresh_preview')
+
+    assert 'refresh=True' in ast.get_source_segment(source, refresh)
+    assert "'Updating preview…' if refresh" in source
+
+
+def test_preview_worker_imports_the_fluorescence_channel_helper():
+    source = (pathlib.Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text()
+
+    assert 'from modules import common_utils' in source

--- a/tests/test_quick_enhance.py
+++ b/tests/test_quick_enhance.py
@@ -7,6 +7,7 @@ import pathlib
 import cv2
 import numpy as np
 import pytest
+import tifffile as tf
 
 from modules import image_utils
 from modules.quick_enhance import QuickEnhanceSettings, QuickEnhancer
@@ -249,6 +250,41 @@ def test_composite_tiff_stays_rgb_and_retains_composite_channel_metadata(tmp_pat
     assert output.dtype == np.uint16
     assert significant_bits == 12
     assert metadata['channel'] == 'Composite'
+
+
+def test_rgba_composite_exports_as_rgb_without_rejecting_composite_metadata(tmp_path):
+    source = tmp_path / 'composite_rgba.tif'
+    source_data = np.zeros((16, 16, 4), dtype=np.uint16)
+    source_data[..., 0] = 4095
+    source_data[..., 1] = 1200
+    source_data[..., 3] = 4095
+    tf.imwrite(source, source_data, photometric='rgb')
+
+    exported = QuickEnhancer().export_file(source, QuickEnhanceSettings.for_preset('Auto (Recommended)'))
+    output, significant_bits = image_utils.load_pixels(
+        exported['output_path'], collapse_legacy_false_color=False
+    )
+
+    assert output.shape == (16, 16, 3)
+    assert output.dtype == np.uint16
+    assert significant_bits == 16
+
+
+def test_rgba_composite_png_drops_alpha_before_rgb_tiff_export(tmp_path):
+    source = tmp_path / 'composite_rgba.png'
+    source_data = np.zeros((16, 16, 4), dtype=np.uint8)
+    source_data[..., 1] = 180
+    source_data[..., 3] = 255
+    assert cv2.imwrite(str(source), source_data)
+
+    exported = QuickEnhancer().export_file(source, QuickEnhanceSettings.for_preset('Auto (Recommended)'))
+    output, significant_bits = image_utils.load_pixels(
+        exported['output_path'], collapse_legacy_false_color=False
+    )
+
+    assert output.shape == (16, 16, 3)
+    assert output.dtype == np.uint8
+    assert significant_bits == 8
 
 
 @pytest.mark.parametrize(

--- a/tests/test_quick_enhance_kv.py
+++ b/tests/test_quick_enhance_kv.py
@@ -1,0 +1,44 @@
+"""Quick Enhance KV must parse before the application constructs a window."""
+
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_lumaviewpro_kv_parses_with_quick_enhance_controls():
+    kv_path = Path(__file__).resolve().parents[1] / 'ui' / 'lumaviewpro.kv'
+    script = (
+        'from pathlib import Path; '
+        'from kivy.lang.parser import Parser; '
+        f'path = Path({str(kv_path)!r}); '
+        'Parser(content=path.read_text(encoding="utf-8"), filename=str(path))'
+    )
+    result = subprocess.run([sys.executable, '-c', script], capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_quick_enhance_kv_uses_short_labels_without_custom_controls():
+    kv_path = Path(__file__).resolve().parents[1] / 'ui' / 'lumaviewpro.kv'
+    content = kv_path.read_text(encoding='utf-8')
+    quick_enhance_rule = content[content.index('<QuickEnhanceControls>:'):content.index('<QuickEnhanceUtilityButton@')]
+
+    assert "values: ('Auto (Recommended)', 'Brightfield / Phase', 'Contrast Only')" in quick_enhance_rule
+    assert "text: 'Choose Image'" in quick_enhance_rule
+    assert "text: 'Choose Folder'" in quick_enhance_rule
+    assert "text: 'Show Original' if root.show_after else 'Show Enhanced'" in quick_enhance_rule
+    assert "text: 'Update Preview'" in quick_enhance_rule
+    assert "text: 'Save Folder' if root.source_folder else 'Save Image'" in quick_enhance_rule
+    assert "text: 'Run'" in quick_enhance_rule
+    assert 'disabled: not root.input_ready' in quick_enhance_rule
+    assert 'Custom' not in quick_enhance_rule
+
+
+def test_quick_enhance_documentation_explains_the_short_mode_names():
+    documentation = (
+        Path(__file__).resolve().parents[1] / 'docs' / 'QUICK_ENHANCE.md'
+    ).read_text(encoding='utf-8')
+
+    assert '## Modes' in documentation
+    assert 'Auto (Recommended)' in documentation
+    assert 'Brightfield / Phase' in documentation
+    assert 'Contrast Only' in documentation

--- a/ui/file_dialogs.py
+++ b/ui/file_dialogs.py
@@ -29,6 +29,7 @@ _POST_PROCESSING_CONTEXTS = (
     'apply_composite_gen_to_folder',
     'apply_video_gen_to_folder',
     'apply_zprojection_to_folder',
+    'apply_quick_enhance_to_folder',
 )
 
 
@@ -218,6 +219,8 @@ class FileChooseBTN(HoverBehavior, Button):
             filetypes_tk = [('TSV', '.tsv')]
         elif self.context == 'load_cell_count_input_image':
             filetypes_tk = [('TIFF', '.tif .tiff')]
+        elif self.context == 'load_quick_enhance_input_image':
+            filetypes_tk = [('Images', '.tif .tiff .png .jpg .jpeg .bmp')]
         elif self.context == 'load_cell_count_method':
             filetypes_tk = [('JSON', '.json')]
         elif self.context == 'load_graphing_data':
@@ -269,6 +272,9 @@ class FileChooseBTN(HoverBehavior, Button):
 
             elif self.context == 'load_cell_count_input_image':
                 ctx.cell_count_content.set_preview_source_file(file=self.selection[0])
+
+            elif self.context == 'load_quick_enhance_input_image':
+                ctx.quick_enhance_controls.set_source_file(file=self.selection[0])
 
             elif self.context == 'load_graphing_data':
                 ctx.graphing_controls.set_graphing_source(file=self.selection[0])
@@ -377,6 +383,8 @@ class FolderChooseBTN(HoverBehavior, Button):
             ctx.video_creation_controls.run_video_gen(path=pathlib.Path(path))
         elif self.context == 'apply_zprojection_to_folder':
             ctx.zprojection_controls.run_zprojection(path=pathlib.Path(path))
+        elif self.context == 'apply_quick_enhance_to_folder':
+            ctx.quick_enhance_controls.set_source_folder(path=pathlib.Path(path))
         else:
             raise Exception(f'on_selection_function(): Unknown selection {self.context}')
 

--- a/ui/image_utils_kivy.py
+++ b/ui/image_utils_kivy.py
@@ -29,7 +29,11 @@ def image_to_texture(image, existing: Texture | None = None) -> Texture:
     # Vertical flip
     image = cv2.flip(image, 0)
 
-    if not image_utils.is_color_image(image=image):
+    if image.ndim == 3 and image.shape[2] == 4:
+        # TIFF data is RGB-native. Kivy's reusable display texture is BGR,
+        # so discard alpha while converting the RGB components to BGR.
+        image = cv2.cvtColor(image, cv2.COLOR_RGBA2BGR)
+    elif not image_utils.is_color_image(image=image):
         image = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
 
     buf = image.tobytes()

--- a/ui/lumaviewpro.kv
+++ b/ui/lumaviewpro.kv
@@ -1727,6 +1727,149 @@
 	# Empty widget to consume space at bottom of controls panel
 	Widget:
 
+<QuickEnhanceControls>:
+	orientation: 'vertical'
+	padding: '8dp'
+	spacing: '6dp'
+	disabled: app.protocol_running or root.busy
+	canvas.before:
+		Color:
+			rgba: 0.08, 0.11, 0.14, 1
+		RoundedRectangle:
+			pos: self.x + dp(2), self.y + dp(2)
+			size: self.width - dp(4), self.height - dp(4)
+			radius: [dp(8)]
+
+	Label:
+		text: 'Quick Enhance is for visual inspection and derived exports.\\nUse raw images for quantitative analysis.'
+		font_size: '11sp'
+		color: 0.86, 0.91, 0.95, 1
+		text_size: self.width, None
+		size_hint_y: None
+		height: '42dp'
+
+	Label:
+		text: 'Input'
+		font_size: '12sp'
+		bold: True
+		color: 0.96, 0.98, 1, 1
+		size_hint_y: None
+		height: '18dp'
+	BoxLayout:
+		size_hint_y: None
+		height: '36dp'
+		QuickEnhanceFileChooseButton:
+			text: 'Choose Image'
+			on_release: self.choose('load_quick_enhance_input_image')
+		QuickEnhanceFolderChooseButton:
+			text: 'Choose Folder'
+			on_release: self.choose('apply_quick_enhance_to_folder')
+	Label:
+		text: 'Run'
+		font_size: '12sp'
+		bold: True
+		color: 0.96, 0.98, 1, 1
+		size_hint_y: None
+		height: '18dp'
+	Spinner:
+		id: quick_enhance_preset
+		text: root.preset
+		values: ('Auto (Recommended)', 'Brightfield / Phase', 'Contrast Only')
+		size_hint_y: None
+		height: '36dp'
+		background_normal: ''
+		background_color: 0.18, 0.25, 0.31, 1
+		color: 1, 1, 1, 1
+		on_text: root.preset = self.text
+	BoxLayout:
+		size_hint_y: None
+		height: '36dp'
+		QuickEnhanceUtilityButton:
+			text: 'Show Original' if root.show_after else 'Show Enhanced'
+			disabled: not root.source_path
+			on_release: root.toggle_before_after()
+		QuickEnhanceUtilityButton:
+			text: 'Update Preview'
+			disabled: not root.source_path
+			on_release: root.refresh_preview()
+	Label:
+		text: 'Save'
+		font_size: '12sp'
+		bold: True
+		color: 0.96, 0.98, 1, 1
+		size_hint_y: None
+		height: '18dp'
+	QuickEnhancePrimaryButton:
+		text: 'Save Folder' if root.source_folder else 'Save Image'
+		size_hint_y: None
+		height: '38dp'
+		disabled: not root.input_ready
+		on_release: root.export()
+	Label:
+		text: root.status_text
+		font_size: '10sp'
+		text_size: self.width, None
+		size_hint_y: None
+		height: '54dp'
+		halign: 'left'
+		valign: 'middle'
+	QuickEnhanceUtilityButton:
+		text: 'Show Output Folder'
+		size_hint_y: None
+		height: '36dp'
+		disabled: not root.last_output_folder
+		on_release: root.open_output_folder()
+	Image:
+		id: quick_enhance_preview_image
+		fit_mode: 'contain'
+		opacity: 1 if self.texture else 0
+
+<QuickEnhanceUtilityButton@RoundedButton>:
+	font_size: '12sp'
+	color: 0.96, 0.98, 1, 1
+	canvas.before:
+		Color:
+			rgba: (0.22, 0.30, 0.37, 1) if not self.disabled else (0.13, 0.16, 0.19, 1)
+		RoundedRectangle:
+			pos: self.pos
+			size: self.size
+			radius: [dp(6)]
+
+<QuickEnhanceFileChooseButton@FileChooseBTN>:
+	font_size: '12sp'
+	color: 0.96, 0.98, 1, 1
+	canvas.before:
+		Color:
+			rgba: (0.22, 0.30, 0.37, 1) if not self.disabled else (0.13, 0.16, 0.19, 1)
+		RoundedRectangle:
+			pos: self.pos
+			size: self.size
+			radius: [dp(6)]
+
+<QuickEnhanceFolderChooseButton@FolderChooseBTN>:
+	font_size: '12sp'
+	color: 0.96, 0.98, 1, 1
+	canvas.before:
+		Color:
+			rgba: (0.22, 0.30, 0.37, 1) if not self.disabled else (0.13, 0.16, 0.19, 1)
+		RoundedRectangle:
+			pos: self.pos
+			size: self.size
+			radius: [dp(6)]
+
+<QuickEnhancePrimaryButton@RoundedButton>:
+	font_size: '12sp'
+	bold: True
+	color: (1, 1, 1, 1) if not self.disabled else (0.52, 0.59, 0.64, 1)
+	canvas.before:
+		Color:
+			rgba: (0.10, 0.52, 0.78, 1) if self.state == 'normal' and not self.disabled else (0.10, 0.13, 0.16, 1)
+		RoundedRectangle:
+			pos: self.pos
+			size: self.size
+			radius: [dp(6)]
+
+
 # PostProcessingAccordion - Settings for PostProcessingAccordion
 # ------------------------------------------
 <PostProcessingAccordion>:
@@ -1780,6 +1923,15 @@
 
 			ZProjectionControls:
 				id: zprojection_controls_id
+
+		AccordionItem:
+			id: quick_enhance_accordion_id
+			title: 'Quick Enhance'
+			on_collapse: root.accordion_collapse()
+			background_normal: './data/icons/post_processing_background.png'
+
+			QuickEnhanceControls:
+				id: quick_enhance_controls_id
 
 		# AccordionItem:
 		# 	id: open_last_save_folder_accordion_id

--- a/ui/post_processing.py
+++ b/ui/post_processing.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas as pd
 
 from kivy.clock import Clock
-from kivy.properties import BooleanProperty
+from kivy.properties import BooleanProperty, StringProperty
 from kivy.uix.boxlayout import BoxLayout
 from kivy.uix.floatlayout import FloatLayout
 from kivy.uix.popup import Popup
@@ -27,14 +27,216 @@ from modules.sequential_io_executor import IOTask
 from modules.stitcher import Stitcher
 from modules.composite_generation import CompositeGeneration
 from modules.video_builder import VideoBuilder
+from modules import common_utils
 from modules.common_utils import CustomJSONizer
 import modules.zprojector as zprojector
 import modules.post_processing as post_processing
+from modules.quick_enhance import QuickEnhanceSettings, QuickEnhancer, QUANTITATIVE_USE_WARNING
 import modules.image_utils as image_utils
 import ui.image_utils_kivy as image_utils_kivy
 import modules.app_context as _app_ctx
 
 logger = logging.getLogger('LVP.ui.post_processing')
+
+
+class QuickEnhanceControls(BoxLayout):
+    """GUI shell for the non-destructive Quick Enhance derived-file path."""
+
+    done = BooleanProperty(False)
+    preset = StringProperty('Auto (Recommended)')
+    source_path = StringProperty('')
+    source_folder = StringProperty('')
+    last_output_folder = StringProperty('')
+    status_text = StringProperty(QUANTITATIVE_USE_WARNING)
+    input_ready = BooleanProperty(False)
+    busy = BooleanProperty(False)
+    show_after = BooleanProperty(False)
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        _app_ctx.register_early('quick_enhance_controls', self)
+        self._enhancer = QuickEnhancer()
+        self._source_preview = None
+        self._enhanced_preview = None
+        self._significant_bits = None
+        self._export_inflight = False
+
+    def set_source_file(self, file, *, refresh: bool = False) -> None:
+        path = pathlib.Path(file)
+        self.source_path = str(path)
+        self.source_folder = ''
+        self.input_ready = False
+        self.busy = True
+        self.status_text = 'Updating preview…' if refresh else 'Loading image preview…'
+        _app_ctx.ctx.file_io_executor.put(
+            IOTask(
+                action=self._load_preview,
+                args=(path, self._settings()),
+                callback=self._preview_callback,
+                pass_result=True,
+                silent_on_failure=True,
+            )
+        )
+
+    def set_source_folder(self, path) -> None:
+        folder = pathlib.Path(path)
+        self.source_folder = str(folder)
+        self.source_path = ''
+        self.input_ready = folder.is_dir()
+        self.status_text = (
+            f'Folder selected: {folder.name}. Folder export is ready; preview controls require Select Image.'
+        )
+
+    def _settings(self) -> QuickEnhanceSettings:
+        return QuickEnhanceSettings.for_preset(self.preset)
+
+    def on_preset(self, *_args) -> None:
+        self.refresh_preview()
+
+    def refresh_preview(self) -> None:
+        if not self.source_path or self.busy:
+            return
+        self.set_source_file(self.source_path, refresh=True)
+
+    @staticmethod
+    def _load_preview(path: pathlib.Path, settings: QuickEnhanceSettings) -> dict:
+        enhancer = QuickEnhancer()
+        settings, detection = enhancer.settings_for_source(path, settings)
+        image, significant_bits = image_utils.load_pixels(path)
+        before, after = enhancer.preview(image, settings, significant_bits)
+        channel = enhancer._source_channel(path)
+        before = enhancer.colorize_mono_for_visual_output(before, channel)
+        after = enhancer.colorize_mono_for_visual_output(after, channel)
+        if channel in common_utils.get_image_layers() and before.ndim == 3:
+            # image_to_texture receives BGR bytes; the false-color helper
+            # deliberately returns RGB for TIFF export and metadata symmetry.
+            before = before[..., ::-1].copy()
+            after = after[..., ::-1].copy()
+        return {
+            'before': before,
+            'after': after,
+            'significant_bits': significant_bits,
+            'detection': detection,
+        }
+
+    def _preview_callback(self, result=None, exception=None) -> None:
+        self.busy = False
+        if exception is not None or result is None:
+            logger.error('[QuickEnhance] Preview failed', exc_info=exception)
+            self.input_ready = False
+            self.status_text = 'Could not load this image. Choose a supported image file.'
+            return
+        self._source_preview = result['before']
+        self._enhanced_preview = result['after']
+        self._significant_bits = result['significant_bits']
+        self.input_ready = True
+        self.status_text = f'{result["detection"]} {QUANTITATIVE_USE_WARNING}'
+        self._show_selected_preview()
+
+    def toggle_before_after(self) -> None:
+        self.show_after = not self.show_after
+        self._show_selected_preview()
+
+    def _show_selected_preview(self) -> None:
+        image = self._enhanced_preview if self.show_after else self._source_preview
+        if image is None or 'quick_enhance_preview_image' not in self.ids:
+            return
+        widget = self.ids['quick_enhance_preview_image']
+        widget.texture = image_utils_kivy.image_to_texture(image, existing=widget.texture)
+
+    def open_output_folder(self) -> None:
+        if not self.last_output_folder:
+            return
+        _app_ctx.ctx.last_save_folder = self.last_output_folder
+        open_last_save_folder()
+
+    @show_popup
+    def export(self, popup) -> None:
+        if self._export_inflight:
+            self.status_text = 'Quick Enhance export is still running in the background.'
+            popup.dismiss()
+            return
+        if not self.input_ready:
+            popup.dismiss()
+            return
+        settings = self._settings()
+        errors = self._enhancer.validate(
+            settings,
+            np.dtype(np.uint16 if self._significant_bits and self._significant_bits > 8 else np.uint8),
+            self._significant_bits or 8,
+        )
+        if errors:
+            self.status_text = ' '.join(errors)
+            popup.dismiss()
+            return
+        target = pathlib.Path(self.source_folder or self.source_path)
+        target_is_folder = bool(self.source_folder)
+        self._export_inflight = True
+        popup.title = 'Quick Enhance'
+        popup.text = 'Creating derived image export… Closing this window does not cancel export.'
+        popup.progress = 0
+        popup.auto_dismiss = False
+        _app_ctx.ctx.file_io_executor.put(
+            IOTask(
+                action=self._export_target,
+                args=(popup, target, target_is_folder, settings),
+                callback=self._export_callback,
+                cb_args=(popup,),
+                pass_result=True,
+                silent_on_failure=True,
+                slow_task_threshold_sec=30.0,
+            )
+        )
+
+    def _export_target(
+        self,
+        popup,
+        target: pathlib.Path,
+        target_is_folder: bool,
+        settings: QuickEnhanceSettings,
+    ) -> dict:
+        if target_is_folder:
+            return self._enhancer.export_folder(
+                target,
+                settings,
+                progress_callback=lambda done, total, path: self._update_folder_progress(
+                    popup, done, total, path
+                ),
+            )
+        result = self._enhancer.export_file(target, settings)
+        self._update_folder_progress(popup, 1, 1, target)
+        return {'status': True, 'created_count': 1, 'created': [result], 'skipped': [], 'total': 1}
+
+    @staticmethod
+    def _update_folder_progress(popup, completed: int, total: int, path: pathlib.Path) -> None:
+        popup.progress = 100 if total == 0 else (completed / total) * 100
+        popup.text = f'Quick Enhance: {completed}/{total} — {path.name}'
+
+    def _export_callback(self, popup, result=None, exception=None) -> None:
+        self.busy = False
+        self._export_inflight = False
+        from modules.notification_center import notifications
+
+        if exception is not None or result is None:
+            logger.error('[QuickEnhance] Export failed', exc_info=exception)
+            popup.dismiss()
+            self.status_text = 'Quick Enhance failed. See the log for details.'
+            notifications.warning('Quick Enhance', 'Export failed', self.status_text)
+            return
+        popup.progress = 100
+        created = result['created_count']
+        skipped = len(result['skipped'])
+        summary = f'Created {created} derived image(s).'
+        if skipped:
+            summary += f' Skipped {skipped} unreadable image(s).'
+        output_folder = self._enhancer.output_folder(result)
+        if output_folder is not None:
+            self.last_output_folder = str(output_folder)
+            summary += f' Saved in: {output_folder}'
+        popup.text = summary
+        self.status_text = f'{summary} {QUANTITATIVE_USE_WARNING}'
+        notifications.info('Quick Enhance', 'Export complete', summary)
+        Clock.schedule_once(lambda _dt: popup.dismiss(), 2)
 
 
 class StitchControls(BoxLayout):


### PR DESCRIPTION
## Summary

Adds a non-destructive Quick Enhance workflow for visual image inspection and derived TIFF export.

## What changed

- Added image and folder Quick Enhance input flows.
- Added Auto, Brightfield / Phase, and Contrast Only modes.
- Added before/after preview, preview refresh, progress feedback, derived-output location, and clear disabled Save behavior.
- Supports TIFF, PNG, JPEG, brightfield, composite, and fluorescence inputs.
- Green, Red, and Blue mono fluorescence images now preview and export in their channel color on black.
- Derived files do not overwrite raw source images and include a recipe sidecar.