### PR TITLE
Integrate Quick Enhance and safe stitching into 4.0 beta

### DIFF
--- a/docs/testing/stitching-safety.tdd.md
+++ b/docs/testing/stitching-safety.tdd.md
@@ -1,0 +1,44 @@
+# Stitching Safety TDD Evidence
+
+Source plan: user journeys and acceptance criteria derived in this TDD run.
+
+## User journeys
+
+- As a microscope user, I can run Fast Preview without an unconstrained panorama algorithm so I can rapidly inspect tile geometry.
+- As a microscope user, I can run Quality Stitch without changing source pixels, channel identity, or brightfield values.
+- As a microscope user, a 0% overlap scan is placed from recorded stage geometry without invented registration.
+- As a support user, I see a plain-language popup while exact diagnostics remain in the application log.
+
+## RED and GREEN evidence
+
+The initial RED run was:
+
+```text
+.venv/bin/python -m pytest tests/test_stitcher.py -q
+ImportError: cannot import name 'infer_stage_overlap'
+```
+
+The final GREEN run was:
+
+```text
+.venv/bin/python -m pytest tests/test_stitcher.py tests/test_stitcher_plugin.py tests/test_issue_166_kv_lock_bindings.py -q
+68 passed
+```
+
+`git diff --check` and `py_compile` also passed for the production Python files.
+
+## Guarantees
+
+| Guarantee | Test target | Result |
+|---|---|---|
+| Recorded stage spacing that equals tile size is treated as 0% overlap. | `TestStageConstrainedStitchModes.test_infers_zero_overlap_from_stage_spacing` | PASS |
+| Quality at 0% overlap never invokes feature matching or overlap registration. | `test_quality_at_zero_overlap_uses_geometry_without_feature_matching` | PASS |
+| Source-preserving composition does not average overlapping source pixels. | `test_source_preserving_mode_never_averages_overlap_pixels` | PASS |
+| Quality with real overlap uses bounded local registration. | `test_quality_overlap_route_uses_bounded_local_registration` | PASS |
+| The user popup does not expose raw worker messages and directs support to logs. | `test_stitcher_popup_never_surfaces_raw_worker_message` | PASS |
+| The UI declares Fast Preview, Quality, and estimate behavior. | `test_stitch_ui_explains_modes_and_time_estimation` | PASS |
+
+## Known validation gap
+
+The active virtual environment has neither `ruff` nor `coverage` installed, so lint and coverage could not be run. No claim of 80% coverage is made here. The focused pytest suite and Python compile checks are the completed local validation.
+

--- a/docs/testing/stitching-safety.tdd.md
+++ b/docs/testing/stitching-safety.tdd.md
@@ -22,7 +22,7 @@ The final GREEN run was:
 
 ```text
 .venv/bin/python -m pytest tests/test_stitcher.py tests/test_stitcher_plugin.py tests/test_issue_166_kv_lock_bindings.py -q
-68 passed
+70 passed
 ```
 
 `git diff --check` and `py_compile` also passed for the production Python files.
@@ -37,8 +37,8 @@ The final GREEN run was:
 | Quality with real overlap uses bounded local registration. | `test_quality_overlap_route_uses_bounded_local_registration` | PASS |
 | The user popup does not expose raw worker messages and directs support to logs. | `test_stitcher_popup_never_surfaces_raw_worker_message` | PASS |
 | The UI declares Fast Preview, Quality, and estimate behavior. | `test_stitch_ui_explains_modes_and_time_estimation` | PASS |
+| Prebuilt composites are excluded from raw-channel stitching. | `test_stitcher_ignores_prebuilt_composites` | PASS |
 
 ## Known validation gap
 
 The active virtual environment has neither `ruff` nor `coverage` installed, so lint and coverage could not be run. No claim of 80% coverage is made here. The focused pytest suite and Python compile checks are the completed local validation.
-

--- a/modules/protocol_post_processor.py
+++ b/modules/protocol_post_processor.py
@@ -187,6 +187,7 @@ class ProtocolPostProcessor(abc.ABC):
         last_error = None
         degraded_outputs = []
         output_significant_bits = None
+        completed_group_ms = []
 
         for _, group in groups:
             if len(group) == 0:
@@ -249,6 +250,8 @@ class ProtocolPostProcessor(abc.ABC):
                 logger.error(f'Failed to generate {output_file_loc_rel}: {alg_results.error}')
                 continue
 
+            completed_group_ms.append(group_ms)
+
             alg_metadata = alg_results.record_metadata
             logger.info(
                 f'[StitchPerf] {self._name} group done in {group_ms:.1f}ms: '
@@ -299,6 +302,20 @@ class ProtocolPostProcessor(abc.ABC):
 
             if popup is not None:
                 popup.progress = (new_count / group_count) * 100
+                if self._name == 'Stitcher':
+                    mode_label = (
+                        'Fast Preview'
+                        if kwargs.get('stitching_mode') == 'fast_preview'
+                        else 'Quality'
+                    )
+                    remaining = max(0, group_count - current_group)
+                    average_ms = sum(completed_group_ms) / len(completed_group_ms)
+                    estimate_seconds = round((remaining * average_ms) / 1000.0)
+                    popup.text = (
+                        f'Running {mode_label} Stitch — group {current_group}/{group_count}.\n'
+                        f'Estimated remaining time: about {estimate_seconds} seconds.\n'
+                        'Source pixels and channel colors are preserved.'
+                    )
 
         protocol_post_record.complete()
 

--- a/modules/stitch_algorithms.py
+++ b/modules/stitch_algorithms.py
@@ -304,6 +304,41 @@ def estimate_overlap_offset(
     return best
 
 
+def estimate_phase_offset(
+    reference: np.ndarray,
+    moving: np.ndarray,
+    nominal_dx: int,
+    nominal_dy: int,
+    max_correction_px: int = 12,
+    min_overlap_px: int = 16,
+) -> tuple[int, int, float]:
+    """Bounded FFT phase-correlation correction for a known overlap edge.
+
+    This is deliberately not OpenCV's unconstrained panorama stitcher.  The
+    recorded stage position defines the only search region; a low-signal,
+    no-overlap, or implausibly-large correction returns the nominal placement.
+    """
+    ref_gray = _gray_float(reference)
+    mov_gray = _gray_float(moving)
+    views = _overlap_views(ref_gray, mov_gray, nominal_dx, nominal_dy)
+    if views is None:
+        return 0, 0, -1.0
+    ref_view, mov_view = views
+    if ref_view.shape[0] < min_overlap_px or ref_view.shape[1] < min_overlap_px:
+        return 0, 0, -1.0
+    if float(ref_view.std()) <= 1e-6 or float(mov_view.std()) <= 1e-6:
+        return 0, 0, -1.0
+    window = cv2.createHanningWindow((ref_view.shape[1], ref_view.shape[0]), cv2.CV_32F)
+    shift, response = cv2.phaseCorrelate(
+        ref_view.astype(np.float32), mov_view.astype(np.float32), window
+    )
+    corr_x = int(round(-shift[0]))
+    corr_y = int(round(-shift[1]))
+    if abs(corr_x) > max_correction_px or abs(corr_y) > max_correction_px:
+        return 0, 0, float(response)
+    return corr_x, corr_y, float(response)
+
+
 def _grid_keys(tiles: list[dict]) -> tuple[list[int], list[int], dict[tuple[int, int], int]]:
     x_values = sorted({int(tile['x_px']) for tile in tiles})
     y_values = sorted({int(tile['y_px']) for tile in tiles})
@@ -315,6 +350,7 @@ def align_tile_positions(
     tiles: list[dict],
     max_correction_px: int = 12,
     min_overlap_px: int = 16,
+    estimator=estimate_overlap_offset,
 ) -> list[dict]:
     """Return tiles with overlap-registered x/y placement corrections.
 
@@ -374,7 +410,7 @@ def align_tile_positions(
             if nidx is None or nidx in offsets:
                 continue
             edge_t0 = time.perf_counter()
-            corr_x, corr_y, score = estimate_overlap_offset(
+            corr_x, corr_y, score = estimator(
                 reference=tiles[idx]['tile'],
                 moving=tiles[nidx]['tile'],
                 nominal_dx=nx - x,
@@ -439,8 +475,10 @@ def stitch_registered_tiles(
     max_correction_px: int = 12,
     min_overlap_px: int = 16,
     output_shape: tuple[int, int] | None = None,
+    estimator=estimate_overlap_offset,
+    blend_mode: str = 'average',
 ) -> tuple[np.ndarray, list[dict]]:
-    """Register overlapping tiles, then average-blend them into one image."""
+    """Register tiles, then compose them with an explicit pixel policy."""
     if not tiles:
         raise ValueError('Need at least one tile to stitch')
 
@@ -449,6 +487,7 @@ def stitch_registered_tiles(
         tiles=tiles,
         max_correction_px=max_correction_px,
         min_overlap_px=min_overlap_px,
+        estimator=estimator,
     )
     register_ms = (time.perf_counter() - register_t0) * 1000.0
 
@@ -477,6 +516,41 @@ def stitch_registered_tiles(
     else:
         acc_shape = (max_y - min_y, max_x - min_x, sample.shape[2])
         weight_shape = (max_y - min_y, max_x - min_x, 1)
+
+    if blend_mode == 'source_preserving':
+        output = np.zeros(acc_shape, dtype=sample.dtype)
+        covered = np.zeros((max_y - min_y, max_x - min_x), dtype=bool)
+        for tile in registered:
+            image = tile['tile']
+            x0 = int(tile['registered_x_px']) - min_x
+            y0 = int(tile['registered_y_px']) - min_y
+            dst_x0, dst_y0 = max(0, x0), max(0, y0)
+            dst_x1 = min(acc_shape[1], x0 + image.shape[1])
+            dst_y1 = min(acc_shape[0], y0 + image.shape[0])
+            if dst_x1 <= dst_x0 or dst_y1 <= dst_y0:
+                continue
+            src_x0, src_y0 = dst_x0 - x0, dst_y0 - y0
+            src_x1 = src_x0 + (dst_x1 - dst_x0)
+            src_y1 = src_y0 + (dst_y1 - dst_y0)
+            take = ~covered[dst_y0:dst_y1, dst_x0:dst_x1]
+            destination = output[dst_y0:dst_y1, dst_x0:dst_x1]
+            source = image[src_y0:src_y1, src_x0:src_x1]
+            if sample.ndim == 2:
+                destination[take] = source[take]
+            else:
+                destination[take, :] = source[take, :]
+            covered[dst_y0:dst_y1, dst_x0:dst_x1][take] = True
+        logger.info(
+            '[StitchPerf] stitch_registered_tiles register=%.1fms source-preserving '
+            'tiles=%d output_shape=%s output_dtype=%s',
+            register_ms,
+            len(tiles),
+            output.shape,
+            output.dtype,
+        )
+        return output, registered
+    if blend_mode != 'average':
+        raise ValueError(f'Unknown stitch blend mode: {blend_mode}')
 
     # float32 (not float64): each whole-mosaic canvas can be multiple GB, and
     # the blend is an integer-pixel average. Products/sums of uint8/uint16

--- a/modules/stitcher.py
+++ b/modules/stitcher.py
@@ -20,6 +20,10 @@ from modules.protocol_post_record import ProtocolPostRecord
 
 
 class Stitcher(ProtocolPostProcessor):
+    QUALITY_MODE = 'quality'
+    FAST_PREVIEW_MODE = 'fast_preview'
+    _FAST_PREVIEW_SUFFIX = 'FastPreview'
+
     def __init__(self, *args, **kwargs):
         super().__init__(
             *args,
@@ -67,7 +71,10 @@ class Stitcher(ProtocolPostProcessor):
             )
         )
 
-        outfile = f'{self._prepend_capture_root(name, kwargs)}.tiff'
+        prefix = self._prepend_capture_root(name, kwargs)
+        if kwargs.get('stitching_mode') == self.FAST_PREVIEW_MODE:
+            prefix = f'{prefix}_{self._FAST_PREVIEW_SUFFIX}'
+        outfile = f'{prefix}.tiff'
         return outfile
 
     def _filter_ignored_types(self, df: pd.DataFrame) -> pd.DataFrame:
@@ -121,6 +128,7 @@ class Stitcher(ProtocolPostProcessor):
                 df=df[stitch_columns],
                 pixel_size_um=pixel_size_um,
                 output_file_loc=kwargs.get('output_file_loc'),
+                stitching_mode=kwargs.get('stitching_mode', self.QUALITY_MODE),
             )
         )
 

--- a/modules/stitcher.py
+++ b/modules/stitcher.py
@@ -79,6 +79,11 @@ class Stitcher(ProtocolPostProcessor):
 
     def _filter_ignored_types(self, df: pd.DataFrame) -> pd.DataFrame:
 
+        # A composite is a derived display/analysis artifact, not a raw channel
+        # tile. Stitch raw channels first; a composite can only be generated
+        # after those stitched channel geometries agree.
+        df = df[df[PostFunction.COMPOSITE.value] == False]  # noqa: E712 -- pandas mask
+
         # Skip already stitched outputs
         df = df[df[self._post_function.value] == False]  # noqa: E712 -- pandas mask
 

--- a/modules/stitching_core.py
+++ b/modules/stitching_core.py
@@ -20,6 +20,8 @@ import modules.common_utils as common_utils
 import modules.image_utils as image_utils
 from modules.stitch_algorithms import (
     crop_to_content,
+    estimate_overlap_offset,
+    estimate_phase_offset,
     feature_stitch,
     stitch_registered_tiles,
 )
@@ -43,6 +45,48 @@ def _read_tile_with_depth(path: pathlib.Path, filename: str) -> tuple[np.ndarray
 def _read_tile(path: pathlib.Path, filename: str) -> np.ndarray:
     image, _ = _read_tile_with_depth(path, filename)
     return image
+
+
+def infer_stage_overlap(
+    df: pd.DataFrame,
+    *,
+    pixel_size_um: float | None,
+    tile_shape: tuple[int, int],
+) -> dict:
+    """Infer physical overlap from recorded stage spacing, never UI intent.
+
+    A zero-overlap acquisition must not enter any content-registration path.
+    The result is carried into the output/log metadata so support can diagnose
+    what the software actually observed.
+    """
+    result = {
+        'has_overlap': False,
+        'x_percent': None,
+        'y_percent': None,
+        'source': 'stage_coordinates',
+    }
+    if pixel_size_um is None or pixel_size_um <= 0 or len(df) < 2:
+        result['reason'] = 'pixel_size_unavailable'
+        return result
+
+    def percent(values: pd.Series, tile_length: int):
+        positions = np.sort(values.astype(float).unique())
+        steps = np.diff(positions) * 1000.0 / pixel_size_um
+        steps = steps[steps > 0]
+        if steps.size == 0:
+            return None
+        return max(
+            0.0,
+            min(100.0, (1.0 - float(np.median(steps)) / tile_length) * 100.0),
+        )
+
+    result['x_percent'] = percent(df['X'], tile_shape[1])
+    result['y_percent'] = percent(df['Y'], tile_shape[0])
+    result['has_overlap'] = bool(
+        (result['x_percent'] is not None and result['x_percent'] > 0.5)
+        or (result['y_percent'] is not None and result['y_percent'] > 0.5)
+    )
+    return result
 
 
 def _write_output(
@@ -265,6 +309,9 @@ def overlap_stitcher(
     df: pd.DataFrame,
     pixel_size_um: float | None,
     output_file_loc: pathlib.Path | None = None,
+    estimator=estimate_overlap_offset,
+    algorithm: str = 'quality_local_ncc',
+    blend_mode: str = 'source_preserving',
 ) -> dict:
     """Use the newest stage-position + overlap-registration stitch math."""
     center = _center_metadata(df)
@@ -321,6 +368,8 @@ def overlap_stitcher(
         stitched_img, registered_tiles = stitch_registered_tiles(
             tiles,
             output_shape=nominal_output_shape,
+            estimator=estimator,
+            blend_mode=blend_mode,
         )
         logger.info(
             '[StitchPerf] overlap register+blend %.1fms output_shape=%s dtype=%s',
@@ -342,11 +391,30 @@ def overlap_stitcher(
         df=df,
         metadata={
             'center': center,
-            'algorithm': 'overlap_stitcher',
+            'algorithm': algorithm,
             'pixel_size_um': pixel_size_um,
+            'pixel_policy': blend_mode,
             'registered_tiles': registered_tiles,
         },
         significant_bits=image_utils.resolve_output_depth(input_depths),
+    )
+
+
+def fft_phase_stitcher(
+    path: pathlib.Path,
+    df: pd.DataFrame,
+    pixel_size_um: float | None,
+    output_file_loc: pathlib.Path | None = None,
+) -> dict:
+    """Fast, stage-constrained preview registration for real overlaps only."""
+    return overlap_stitcher(
+        path=path,
+        df=df,
+        pixel_size_um=pixel_size_um,
+        output_file_loc=output_file_loc,
+        estimator=estimate_phase_offset,
+        algorithm='fast_fft_phase',
+        blend_mode='source_preserving',
     )
 
 
@@ -555,44 +623,59 @@ def channel_aware_stitcher(
     df: pd.DataFrame,
     pixel_size_um: float | None = None,
     output_file_loc: pathlib.Path | None = None,
+    stitching_mode: str = 'quality',
 ) -> dict:
     """Route channels through the preferred algorithm and fallbacks.
 
-    BF: feature stitch -> overlap registration -> stage-position -> simple grid.
-    Fluorescence/other: overlap registration -> stage-position -> simple grid.
+    Fast Preview uses bounded FFT phase correlation. Quality uses bounded local
+    NCC. Both use recorded stage geometry and retain source pixels; OpenCV's
+    unconstrained panorama stitcher is deliberately not an automatic fallback.
     """
-    color = str(df.iloc[0].get('Color', ''))
+    mode = str(stitching_mode or 'quality').lower()
+    if mode not in {'quality', 'fast_preview'}:
+        return _failure('channel_aware_stitcher', f'unknown stitching mode: {mode}')
+    sample, _ = _read_tile_with_depth(path, df.iloc[0]['Filepath'])
+    overlap = infer_stage_overlap(df, pixel_size_um=pixel_size_um, tile_shape=sample.shape[:2])
+    logger.info(
+        '[Stitch] mode=%s inferred_overlap x=%s%% y=%s%% has_overlap=%s source=%s',
+        mode,
+        overlap['x_percent'],
+        overlap['y_percent'],
+        overlap['has_overlap'],
+        overlap['source'],
+    )
     shared = {
         'path': path,
         'df': df,
         'output_file_loc': output_file_loc,
     }
     chain: list[tuple[str, Callable[[], dict]]] = []
-    if color == 'BF':
+    if overlap['has_overlap'] and mode == 'fast_preview':
         chain.append(
             (
-                'bf_feature_stitcher',
-                lambda: bf_feature_stitcher(**shared),
+                'fast_fft_phase',
+                lambda: fft_phase_stitcher(**shared, pixel_size_um=pixel_size_um),
             )
         )
+    elif overlap['has_overlap']:
+        chain.append(
+            (
+                'quality_local_ncc',
+                lambda: overlap_stitcher(**shared, pixel_size_um=pixel_size_um),
+            )
+        )
+    # At zero overlap, stage placement is the quality-preserving operation.
     chain.extend(
         [
-            (
-                'overlap_stitcher',
-                lambda: overlap_stitcher(**shared, pixel_size_um=pixel_size_um),
-            ),
             (
                 'stage_position_stitcher',
                 lambda: stage_position_stitcher(**shared, pixel_size_um=pixel_size_um),
             ),
-            (
-                'simple_position_stitcher',
-                lambda: simple_position_stitcher(**shared),
-            ),
+            ('simple_position_stitcher', lambda: simple_position_stitcher(**shared)),
         ]
     )
     row0 = df.iloc[0]
-    return _run_fallback_chain(
+    result = _run_fallback_chain(
         chain,
         context={
             'well': row0.get('Well', ''),
@@ -600,3 +683,7 @@ def channel_aware_stitcher(
             'tile_group_id': row0.get('Tile Group ID', ''),
         },
     )
+    result.setdefault('metadata', {})['mode'] = mode
+    result['metadata']['overlap'] = overlap
+    result['metadata']['pixel_policy'] = 'source_preserving'
+    return result

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -439,10 +439,33 @@ class TestSimplePositionStitcher:
 
         assert degraded_branch, 'stitcher_callback must branch on result["degraded"]'
         branch_source = ast.unparse(degraded_branch[0])
-        assert 'Success (degraded)' in branch_source
+        assert 'geometry-only fallback' in branch_source
         assert 'popup.text' in branch_source
 
-    def test_bf_route_uses_feature_then_overlap_then_stage_then_simple(
+    def test_stitcher_popup_never_surfaces_raw_worker_message(self):
+        source = (
+            pathlib.Path(__file__).resolve().parent.parent / 'ui' / 'post_processing.py'
+        ).read_text()
+        tree = ast.parse(source)
+        callback = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.FunctionDef) and node.name == 'stitcher_callback'
+        )
+        callback_source = ast.unparse(callback)
+        assert 'result[\'message\']' not in callback_source
+        assert 'Support > Logs' in callback_source
+
+    def test_stitch_ui_explains_modes_and_time_estimation(self):
+        root = pathlib.Path(__file__).resolve().parent.parent
+        kv_source = (root / 'ui' / 'lumaviewpro.kv').read_text()
+        ui_source = (root / 'ui' / 'post_processing.py').read_text()
+        assert 'Fast Preview: bounded FFT geometry check' in kv_source
+        assert 'Quality: bounded local registration' in kv_source
+        assert 'Estimated remaining time' in (root / 'modules' / 'protocol_post_processor.py').read_text()
+        assert 'stitching_mode' in ui_source
+
+    def test_bf_quality_route_never_uses_unconstrained_feature_stitcher(
         self,
         tmp_path,
         monkeypatch,
@@ -458,7 +481,7 @@ class TestSimplePositionStitcher:
                 },
                 {
                     'Filepath': 'b.tiff',
-                    'X': 1.0,
+                    'X': 0.050,
                     'Y': 0.0,
                     'Objective': '10x Oly',
                     'Color': 'BF',
@@ -492,8 +515,12 @@ class TestSimplePositionStitcher:
             }
 
         monkeypatch.setattr(
+            'modules.stitching_core._read_tile_with_depth',
+            lambda *_: (np.ones((100, 100), dtype=np.uint8), 8),
+        )
+        monkeypatch.setattr(
             'modules.stitching_core.bf_feature_stitcher',
-            fail('bf_feature_stitcher'),
+            lambda *_args, **_kwargs: pytest.fail('BF feature stitch must not be automatic'),
         )
         monkeypatch.setattr('modules.stitching_core.overlap_stitcher', fail('overlap_stitcher'))
         monkeypatch.setattr(
@@ -506,13 +533,12 @@ class TestSimplePositionStitcher:
 
         assert result['status'] is True
         assert calls == [
-            'bf_feature_stitcher',
             'overlap_stitcher',
             'stage_position_stitcher',
             'simple_position_stitcher',
         ]
         assert result['metadata']['algorithm'] == 'simple_position_stitcher'
-        assert result['metadata']['fallback_from'] == 'bf_feature_stitcher'
+        assert result['metadata']['fallback_from'] == 'quality_local_ncc'
 
     def test_fallback_logs_operator_visible_warning(
         self,
@@ -533,7 +559,7 @@ class TestSimplePositionStitcher:
                 },
                 {
                     'Filepath': 'b.tiff',
-                    'X': 1.0,
+                    'X': 0.050,
                     'Y': 0.0,
                     'Objective': '10x Oly',
                     'Color': 'Green',
@@ -564,12 +590,16 @@ class TestSimplePositionStitcher:
 
         monkeypatch.setattr('modules.stitching_core.overlap_stitcher', overlap_fail)
         monkeypatch.setattr('modules.stitching_core.stage_position_stitcher', stage_success)
+        monkeypatch.setattr(
+            'modules.stitching_core._read_tile_with_depth',
+            lambda *_: (np.ones((100, 100), dtype=np.uint8), 8),
+        )
 
         with caplog.at_level(logging.WARNING, logger='LVP.modules.stitching_core'):
             result = channel_aware_stitcher(tmp_path, df, pixel_size_um=1.0)
 
         assert result['status'] is True
-        assert result['metadata']['fallback_from'] == 'overlap_stitcher'
+        assert result['metadata']['fallback_from'] == 'quality_local_ncc'
         assert 'using stage_position_stitcher for well=A1 color=Green tile_group=3' in caplog.text
 
     def test_fluorescence_route_uses_overlap_then_stage_then_simple(
@@ -588,7 +618,7 @@ class TestSimplePositionStitcher:
                 },
                 {
                     'Filepath': 'b.tiff',
-                    'X': 1.0,
+                    'X': 0.050,
                     'Y': 0.0,
                     'Objective': '10x Oly',
                     'Color': 'Green',
@@ -631,13 +661,17 @@ class TestSimplePositionStitcher:
             fail('stage_position_stitcher'),
         )
         monkeypatch.setattr('modules.stitching_core.simple_position_stitcher', simple_success)
+        monkeypatch.setattr(
+            'modules.stitching_core._read_tile_with_depth',
+            lambda *_: (np.ones((100, 100), dtype=np.uint8), 8),
+        )
 
         result = channel_aware_stitcher(tmp_path, df, pixel_size_um=1.0)
 
         assert result['status'] is True
         assert calls == ['overlap_stitcher', 'stage_position_stitcher', 'simple_position_stitcher']
         assert result['metadata']['algorithm'] == 'simple_position_stitcher'
-        assert result['metadata']['fallback_from'] == 'overlap_stitcher'
+        assert result['metadata']['fallback_from'] == 'quality_local_ncc'
 
 
 class TestPositionAwareStitcher:
@@ -926,3 +960,22 @@ class TestStageConstrainedStitchModes:
         )
         assert np.all(output[:, :4] == 10)
         assert np.all(output[:, 4:] == 200)
+
+    def test_quality_overlap_route_uses_bounded_local_registration(self, tmp_path):
+        rng = np.random.default_rng(123)
+        base = rng.integers(0, 255, (100, 150), dtype=np.uint8)
+        cv2.imwrite(str(tmp_path / 'left.tiff'), base[:, :100])
+        cv2.imwrite(str(tmp_path / 'right.tiff'), base[:, 50:150])
+        frame = pd.DataFrame(
+            [
+                {'Filepath': 'left.tiff', 'X': 0.050, 'Y': 0.0, 'Color': 'BF'},
+                {'Filepath': 'right.tiff', 'X': 0.0, 'Y': 0.0, 'Color': 'BF'},
+            ]
+        )
+
+        result = channel_aware_stitcher(tmp_path, frame, pixel_size_um=1.0)
+
+        assert result['status'] is True
+        assert result['metadata']['algorithm'] == 'quality_local_ncc'
+        assert result['metadata']['pixel_policy'] == 'source_preserving'
+        assert result['metadata']['overlap']['has_overlap'] is True

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -979,3 +979,41 @@ class TestStageConstrainedStitchModes:
         assert result['metadata']['algorithm'] == 'quality_local_ncc'
         assert result['metadata']['pixel_policy'] == 'source_preserving'
         assert result['metadata']['overlap']['has_overlap'] is True
+
+    def test_fast_preview_overlap_route_uses_fft_not_quality_ncc(self, tmp_path, monkeypatch):
+        frame = pd.DataFrame(
+            [
+                {'Filepath': 'a.tiff', 'X': 0.050, 'Y': 0.0, 'Color': 'BF'},
+                {'Filepath': 'b.tiff', 'X': 0.0, 'Y': 0.0, 'Color': 'BF'},
+            ]
+        )
+        calls = []
+
+        def fft_success(*args, **kwargs):
+            calls.append('fft')
+            return {
+                'status': True,
+                'error': None,
+                'image': np.zeros((100, 150), dtype=np.uint8),
+                'significant_bits': 8,
+                'metadata': {'center': {'x': 0.025, 'y': 0.0}},
+            }
+
+        monkeypatch.setattr(
+            'modules.stitching_core._read_tile_with_depth',
+            lambda *_: (np.ones((100, 100), dtype=np.uint8), 8),
+        )
+        monkeypatch.setattr('modules.stitching_core.fft_phase_stitcher', fft_success)
+        monkeypatch.setattr(
+            'modules.stitching_core.overlap_stitcher',
+            lambda *_args, **_kwargs: pytest.fail('Fast Preview must not use Quality NCC'),
+        )
+
+        result = channel_aware_stitcher(
+            tmp_path, frame, pixel_size_um=1.0, stitching_mode='fast_preview'
+        )
+
+        assert result['status'] is True
+        assert calls == ['fft']
+        assert result['metadata']['algorithm'] == 'fast_fft_phase'
+        assert result['metadata']['mode'] == 'fast_preview'

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -1017,3 +1017,30 @@ class TestStageConstrainedStitchModes:
         assert calls == ['fft']
         assert result['metadata']['algorithm'] == 'fast_fft_phase'
         assert result['metadata']['mode'] == 'fast_preview'
+
+    def test_stitcher_ignores_prebuilt_composites(self):
+        stitcher = Stitcher(has_turret=False)
+        frame = pd.DataFrame(
+            [
+                {
+                    'Filepath': 'raw_bf.tiff',
+                    'Composite': False,
+                    'Stitched': False,
+                    'ZProject': False,
+                    'Video': False,
+                    'Hyperstack': False,
+                },
+                {
+                    'Filepath': 'derived_composite.tiff',
+                    'Composite': True,
+                    'Stitched': False,
+                    'ZProject': False,
+                    'Video': False,
+                    'Hyperstack': False,
+                },
+            ]
+        )
+
+        filtered = stitcher._filter_ignored_types(frame)
+
+        assert filtered['Filepath'].tolist() == ['raw_bf.tiff']

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -154,7 +154,7 @@ class TestCropToContent:
 # Current stitcher.py -- _simple_position_stitcher
 # ---------------------------------------------------------------------------
 
-from modules.stitching_core import channel_aware_stitcher
+from modules.stitching_core import channel_aware_stitcher, infer_stage_overlap
 from modules.stitcher import Stitcher
 import modules.common_utils as common_utils
 import modules.image_utils as image_utils
@@ -856,3 +856,73 @@ def test_float32_blend_is_byte_identical_to_float64(dtype, high, channels):
     )
     reference = _reference_blend_float64(registered, left)
     assert np.array_equal(out, reference), 'float32 blend diverged from float64'
+
+
+class TestStageConstrainedStitchModes:
+    """Production routing must never use unconstrained panorama matching."""
+
+    def test_infers_zero_overlap_from_stage_spacing(self):
+        frame = pd.DataFrame(
+            [
+                {'X': 0.0, 'Y': 0.0},
+                {'X': 0.100, 'Y': 0.0},
+                {'X': 0.0, 'Y': 0.100},
+                {'X': 0.100, 'Y': 0.100},
+            ]
+        )
+        overlap = infer_stage_overlap(frame, pixel_size_um=1.0, tile_shape=(100, 100))
+        assert overlap['has_overlap'] is False
+        assert overlap['x_percent'] == pytest.approx(0.0)
+        assert overlap['y_percent'] == pytest.approx(0.0)
+
+    def test_quality_at_zero_overlap_uses_geometry_without_feature_matching(
+        self, tmp_path, monkeypatch
+    ):
+        frame = pd.DataFrame(
+            [
+                {'Filepath': 'a.tiff', 'X': 0.0, 'Y': 0.0, 'Color': 'BF'},
+                {'Filepath': 'b.tiff', 'X': 0.100, 'Y': 0.0, 'Color': 'BF'},
+            ]
+        )
+        calls = []
+
+        def should_not_run(*args, **kwargs):
+            raise AssertionError('unconstrained registration must not run at 0% overlap')
+
+        def stage_success(*args, **kwargs):
+            calls.append('stage')
+            return {
+                'status': True,
+                'error': None,
+                'image': np.zeros((10, 20), dtype=np.uint8),
+                'significant_bits': 8,
+                'metadata': {'center': {'x': 0.05, 'y': 0.0}},
+            }
+
+        monkeypatch.setattr('modules.stitching_core._read_tile_with_depth', lambda *_: (np.ones((100, 100), dtype=np.uint8), 8))
+        monkeypatch.setattr('modules.stitching_core.bf_feature_stitcher', should_not_run)
+        monkeypatch.setattr('modules.stitching_core.overlap_stitcher', should_not_run)
+        monkeypatch.setattr('modules.stitching_core.stage_position_stitcher', stage_success)
+
+        result = channel_aware_stitcher(
+            tmp_path, frame, pixel_size_um=1.0, stitching_mode='quality'
+        )
+
+        assert result['status'] is True
+        assert calls == ['stage']
+        assert result['metadata']['algorithm'] == 'stage_position_stitcher'
+        assert result['metadata']['overlap']['has_overlap'] is False
+
+    def test_source_preserving_mode_never_averages_overlap_pixels(self):
+        first = np.full((4, 4), 10, dtype=np.uint8)
+        second = np.full((4, 4), 200, dtype=np.uint8)
+        output, _ = stitch_registered_tiles(
+            [
+                {'tile': first, 'x_px': 0, 'y_px': 0},
+                {'tile': second, 'x_px': 2, 'y_px': 0},
+            ],
+            output_shape=(4, 6),
+            blend_mode='source_preserving',
+        )
+        assert np.all(output[:, :4] == 10)
+        assert np.all(output[:, 4:] == 200)

--- a/ui/lumaviewpro.kv
+++ b/ui/lumaviewpro.kv
@@ -1642,9 +1642,7 @@
 		height: '12dp'
 
 	Label:
-		text: ('Fast Preview: bounded FFT geometry check; use for rapid review.\n'
-		       'Quality: bounded local registration only when stage data shows real overlap.\n'
-		       'At 0% overlap, both use source-preserving stage placement.')
+		text: 'Fast Preview: bounded FFT geometry check; use for rapid review.\nQuality: bounded local registration only when stage data shows real overlap.\nAt 0% overlap, both use source-preserving stage placement.'
 		halign: 'left'
 		valign: 'middle'
 		text_size: self.width, None

--- a/ui/lumaviewpro.kv
+++ b/ui/lumaviewpro.kv
@@ -1639,13 +1639,43 @@
 	# Pad
 	Widget:
 		size_hint_y: None
+		height: '12dp'
+
+	BoxLayout:
+		orientation: 'horizontal'
+		size_hint_y: None
 		height: '30dp'
+		spacing: '5dp'
+		Label:
+			text: 'Stitch Mode'
+			halign: 'left'
+			valign: 'middle'
+			font_size: '12sp'
+			size_hint_x: None
+			width: '120dp'
+		Spinner:
+			id: stitching_mode_spinner
+			text: 'Quality'
+			font_size: '12sp'
+			option_cls: 'SpinnerOption0'
+			on_text: root.stitching_mode = self.text
+
+	Label:
+		text: ('Fast Preview: bounded FFT geometry check; use for rapid review.\n'
+		       'Quality: bounded local registration only when stage data shows real overlap.\n'
+		       'At 0% overlap, both use source-preserving stage placement.')
+		halign: 'left'
+		valign: 'middle'
+		text_size: self.width, None
+		size_hint_y: None
+		height: '54dp'
+		font_size: '11sp'
 
 	FolderChooseBTN:
 
 		id: stitch_apply_btn
-		text: 'Apply Stitching to Protocol Folder'
-        tooltip_text: 'Assemble tiles into stitched montage image of abutted tiles'
+		text: 'Run Selected Stitch Mode…'
+        tooltip_text: 'Fast Preview is the rapid geometry check. Quality is source-preserving and only registers verified overlap.'
 		size_hint_y: None
 		height: '30dp'
 		font_size: '12sp'

--- a/ui/post_processing.py
+++ b/ui/post_processing.py
@@ -241,21 +241,38 @@ class QuickEnhanceControls(BoxLayout):
 
 class StitchControls(BoxLayout):
     done = BooleanProperty(False)
+    stitching_mode = StringProperty('Quality')
+    _MODE_VALUES = {
+        'Quality': Stitcher.QUALITY_MODE,
+        'Fast Preview': Stitcher.FAST_PREVIEW_MODE,
+    }
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         _app_ctx.register_early('stitch_controls', self)
+        Clock.schedule_once(self._init_ui, 0)
+
+    def _init_ui(self, _dt=0):
+        spinner = self.ids['stitching_mode_spinner']
+        spinner.values = tuple(self._MODE_VALUES)
+        spinner.text = self.stitching_mode
 
     def set_button_enabled_state(self, state: bool):
         self.ids['stitch_apply_btn'].disabled = not state
 
     @show_popup
     def run_stitcher(self, popup, path):
-        gui_logger.button('RUN_STITCHER', f'path={path}')
+        mode_label = self.ids['stitching_mode_spinner'].text or self.stitching_mode
+        stitching_mode = self._MODE_VALUES.get(mode_label, Stitcher.QUALITY_MODE)
+        gui_logger.button('RUN_STITCHER', f'path={path} mode={stitching_mode}')
         ctx = _app_ctx.ctx
         status_map = {True: 'Success', False: 'FAILED'}
-        popup.title = 'Stitcher'
-        popup.text = 'Generating stitched images...'
+        popup.title = f'{mode_label} Stitch'
+        popup.text = (
+            f'Running {mode_label} Stitch.\n'
+            'Estimating remaining time after the first tile group.\n'
+            'Source pixels and channel colors are preserved.'
+        )
         popup.progress = 0
         popup.auto_dismiss = False
 
@@ -270,6 +287,7 @@ class StitchControls(BoxLayout):
                     pathlib.Path(ctx.source_path) / 'data' / 'tiling.json',
                     popup,
                 ),
+                kwargs={'stitching_mode': stitching_mode},
                 callback=self.stitcher_callback,
                 cb_args=(popup, status_map),
                 pass_result=True,
@@ -278,20 +296,28 @@ class StitchControls(BoxLayout):
 
     def stitcher_callback(self, popup, status_map, result=None, exception=None):
         if result is None:
-            popup.text = 'Stitching images - FAILED'
+            popup.text = (
+                'Stitching could not be completed. No console error is shown here.\n'
+                'Open Support > Logs and search for “Stitcher:” for the diagnostic details.'
+            )
             Clock.schedule_once(lambda dt: popup.dismiss(), 5)
             return
 
         if result.get('degraded'):
-            final_text = 'Stitching images - Success (degraded)'
-            final_text += f'\n{result.get("message", "Fallback stitching was used.")}'
+            final_text = (
+                'Stitching complete with geometry-only fallback for one or more groups.\n'
+                'Review the mosaic geometry; detailed reasons are in Support > Logs.'
+            )
             popup.text = final_text
             Clock.schedule_once(lambda dt: popup.dismiss(), 5)
             return
 
         final_text = f'Stitching images - {status_map[result["status"]]}'
         if result['status'] is False:
-            final_text += f'\n{result["message"]}'
+            final_text = (
+                'Stitching could not be completed for one or more tile groups.\n'
+                'No console error is shown here. Open Support > Logs and search for “Stitcher:”.'
+            )
             popup.text = final_text
             Clock.schedule_once(lambda dt: popup.dismiss(), 5)
             return


### PR DESCRIPTION
## Summary

Integrates Quick Enhance and the updated stitching workflow into `4.0.0-beta`.

## What changed

- Adds the Quick Enhance derived-image workflow and its UI/tests.
- Replaces automatic OpenCV panorama stitching with stage-constrained stitching.
- Adds separate Quality Stitch and Fast Preview Stitch actions.
- Uses stage-derived overlap: at 0% overlap, both modes use source-preserving stage placement.
- Quality uses bounded local registration only when real overlap is present.
- Fast Preview retains bounded FFT phase registration for rapid visual review.
- Excludes derived composites from raw stitching to prevent mixed composite/single-channel artifacts.
- Improves user-facing errors and adds a remaining-time estimate after the first tile group.

## Root cause addressed

OpenCV panorama/feature stitching could hang or fail on microscopy tiles and could ignore zero-overlap geometry. The replacement keeps registration within recorded stage geometry and preserves source pixels and channel colors.

## Validation

- Quick Enhance unit and UI parsing tests passed.
- Stitching, plugin, and protocol-lock regression tests passed.
- Python syntax and Git whitespace checks passed.

## Notes for reviewers

This branch includes the merge-resolution work required to integrate with the current `4.0.0-beta` code.