### PR TITLE
feat: finalize halo-safe Quick Enhance

### DIFF
--- a/docs/QUICK_ENHANCE.md
+++ b/docs/QUICK_ENHANCE.md
@@ -1,20 +1,22 @@
 # Quick Enhance
 
-Quick Enhance creates a derived TIFF for visual inspection. It never changes the source image. Do not use derived files for quantitative analysis.
+Quick Enhance creates a derived TIFF for visual inspection. It never changes the source image. Do not use derived files for quantitative analysis. For AI-assisted, validated quantitative enhancement workflows, use LumaQuant Pro.
 
 ## Use it
 
 1. Choose Image to inspect and save one image, or Choose Folder to save every supported image in that folder.
-2. Select a mode.
-3. Save Image or Save Folder. Use Show Output Folder when complete.
+2. Select Quick Enhance Image or Quick Enhance Folder. Use Show Output Folder when complete.
 
 Choose Image enables Before / After and Update Preview. A folder is a batch operation, so it has no single-image preview.
 
-## Modes
+## Fixed recipe
 
-- **Auto (Recommended)** — Detects each image independently. BF, phase, and darkfield use the gentle brightfield adjustment. Composite, fluorescence, and unknown images use neutral automatic contrast.
-- **Brightfield / Phase** — Forces the gentle brightfield adjustment (automatic contrast plus light brightening). Use when Auto cannot identify a BF, phase, or darkfield file.
-- **Contrast Only** — Applies automatic contrast only. Use when you do not want the brightfield adjustment.
+Quick Enhance applies the same non-AI recipe to every selected image:
+
+1. **Global illumination correction** fits a field-scale brightness plane and divides by it multiplicatively. It does not follow or subtract individual bright structures, avoiding dark halos around them.
+2. **Auto levels** maps the 1st–99th percentile into the available image range, followed by gentle midtone brightening.
+
+This is classical presentation processing, not AI denoising or restoration. LumaQuant Pro remains the separate AI-assisted cleanup workflow.
 
 ## Buttons
 

--- a/modules/quick_enhance.py
+++ b/modules/quick_enhance.py
@@ -14,7 +14,7 @@ import pathlib
 import re
 import uuid
 from dataclasses import asdict, dataclass
-from collections.abc import Callable
+from typing import Callable
 
 import cv2
 import numpy as np
@@ -26,7 +26,8 @@ from modules import common_utils, image_utils
 PIPELINE_VERSION = '1'
 QUANTITATIVE_USE_WARNING = (
     'Quick Enhance is for visual inspection and derived exports. '
-    'Use raw images for quantitative analysis.'
+    'Use raw images for quantitative analysis. '
+    'For AI-assisted, validated quantitative enhancement workflows, use LumaQuant Pro.'
 )
 # Quick Enhance reads more than the project's own capture format, so this is a
 # superset of the TIFF suffixes rather than an independent list -- the two must
@@ -37,28 +38,14 @@ MAX_IMAGE_PIXELS = 100_000_000
 
 @dataclass(frozen=True)
 class QuickEnhanceSettings:
-    """Conservative settings for a deterministic visual enhancement."""
+    """Fixed, non-AI recipe for deterministic visual enhancement."""
 
-    preset: str = 'Auto (Recommended)'
     low_percentile: float = 1.0
     high_percentile: float = 99.0
-    gamma: float = 1.0
-    background_enabled: bool = False
-    background_sigma: float = 24.0
+    gamma: float = 0.9
+    illumination_correction_enabled: bool = True
     denoise_enabled: bool = False
     denoise_kernel_size: int = 3
-
-    @classmethod
-    def for_preset(cls, preset: str) -> QuickEnhanceSettings:
-        presets = {
-            'Auto (Recommended)': cls(preset='Auto (Recommended)'),
-            'Brightfield / Phase': cls(preset='Brightfield / Phase', gamma=0.9),
-            'Contrast Only': cls(preset='Contrast Only'),
-        }
-        try:
-            return presets[preset]
-        except KeyError as exc:
-            raise ValueError(f'Unknown Quick Enhance preset: {preset}') from exc
 
 
 class QuickEnhancer:
@@ -75,45 +62,15 @@ class QuickEnhancer:
         if dtype not in (np.dtype(np.uint8), np.dtype(np.uint16)):
             errors.append('Quick Enhance supports uint8 and uint16 images only.')
         container_bits = dtype.itemsize * 8
-        if (
-            not isinstance(significant_bits, (int, np.integer))
-            or not 1 <= significant_bits <= container_bits
-        ):
+        if not isinstance(significant_bits, (int, np.integer)) or not 1 <= significant_bits <= container_bits:
             errors.append(f'Significant bits must be between 1 and {container_bits}.')
         if not 0 <= settings.low_percentile < settings.high_percentile <= 100:
             errors.append('Low percentile must be below high percentile, within 0 to 100.')
         if not 0.5 <= settings.gamma <= 2.0:
             errors.append('Gamma must be between 0.5 and 2.0.')
-        if not 1.0 <= settings.background_sigma <= 100.0:
-            errors.append('Background radius must be between 1 and 100 pixels.')
         if settings.denoise_kernel_size not in (3, 5, 7):
             errors.append('Denoise kernel must be 3, 5, or 7 pixels.')
         return errors
-
-    def settings_for_source(
-        self,
-        source_path: str | pathlib.Path,
-        settings: QuickEnhanceSettings,
-    ) -> tuple[QuickEnhanceSettings, str]:
-        """Resolve Auto per file using acquisition metadata, never pixel guesses."""
-        if settings.preset != 'Auto (Recommended)':
-            return settings, f'{settings.preset} selected.'
-        source_path = pathlib.Path(source_path)
-        channel = self._source_channel(source_path)
-        if channel in common_utils.get_transmitted_layers():
-            return (
-                QuickEnhanceSettings.for_preset('Brightfield / Phase'),
-                f'Detected transmitted channel: {channel}.',
-            )
-        if channel == 'Composite':
-            return QuickEnhanceSettings.for_preset('Auto (Recommended)'), 'Detected Composite TIFF.'
-        if channel in common_utils.get_image_layers():
-            return QuickEnhanceSettings.for_preset(
-                'Auto (Recommended)'
-            ), f'Detected fluorescence channel: {channel}.'
-        return QuickEnhanceSettings.for_preset(
-            'Auto (Recommended)'
-        ), 'Image type unknown; using neutral auto levels.'
 
     @staticmethod
     def _source_channel(source_path: pathlib.Path) -> str | None:
@@ -174,27 +131,35 @@ class QuickEnhancer:
             raise ValueError(f'Invalid Quick Enhance settings: {" ".join(errors)}')
 
         source_max = float((1 << int(significant_bits)) - 1)
-        # Work in float so background subtraction cannot wrap unsigned values.
-        # RGB/RGBA receives one shared levels/gamma curve derived from mean
-        # luminance. That keeps channel relationships predictable instead of
-        # independently stretching the component channels into a new composite.
+        # Work in float so illumination correction cannot wrap unsigned values.
+        # RGB/RGBA uses one corrected luminance plane, then scales its source
+        # RGB values together. This preserves colour relationships rather than
+        # independently remapping channels into a new composite.
         work = np.clip(image.astype(np.float32, copy=False), 0.0, source_max) / source_max
-        channels = work if is_mono else work[..., :3].copy()
+        source_channels = work if is_mono else work[..., :3]
+        channels = source_channels.copy()
         if not np.isfinite(work).all():
             channels = np.nan_to_num(channels, nan=0.0, posinf=1.0, neginf=0.0)
+        intensity = channels if is_mono else channels.mean(axis=2)
 
-        if settings.background_enabled and min(image.shape) >= 3:
-            background = cv2.GaussianBlur(
-                channels,
-                (0, 0),
-                sigmaX=float(settings.background_sigma),
-                sigmaY=float(settings.background_sigma),
-                borderType=cv2.BORDER_REPLICATE,
+        if settings.illumination_correction_enabled and min(image.shape) >= 3:
+            illumination = self._global_illumination_plane(intensity)
+            # The global plane corrects field-scale illumination drift without
+            # following individual objects, so it cannot add dark edge halos.
+            # The reference restores the scene's overall brightness.
+            reference = float(np.median(illumination))
+            intensity = np.clip(
+                intensity / np.maximum(illumination, 1.0 / 65535.0) * reference,
+                0.0,
+                1.0,
             )
-            # Keep a conservative low background pedestal; this avoids an
-            # all-black result while removing large-scale uneven illumination.
-            pedestal = np.percentile(background, 5.0, axis=(0, 1), keepdims=True)
-            channels = np.clip(channels - background + pedestal, 0.0, 1.0)
+
+        if is_mono:
+            channels = intensity
+        else:
+            original_intensity = source_channels.mean(axis=2)
+            gain = intensity / np.maximum(original_intensity, 1.0 / 65535.0)
+            channels = np.clip(source_channels * gain[..., np.newaxis], 0.0, 1.0)
 
         if settings.denoise_enabled and min(image.shape) >= settings.denoise_kernel_size:
             channels = cv2.medianBlur(channels, int(settings.denoise_kernel_size))
@@ -222,6 +187,33 @@ class QuickEnhancer:
             return enhanced_channels
         restored[..., :3] = enhanced_channels
         return restored
+
+    @staticmethod
+    def _global_illumination_plane(intensity: np.ndarray) -> np.ndarray:
+        """Fit a robust field-scale illumination plane, never a local object map."""
+        height, width = intensity.shape
+        stride = max(1, int(np.ceil(np.sqrt(intensity.size / 100_000))))
+        sample = intensity[::stride, ::stride]
+        sample_y, sample_x = np.mgrid[0:height:stride, 0:width:stride]
+        values = sample.reshape(-1)
+        finite = np.isfinite(values)
+        if finite.sum() < 3:
+            return np.full_like(intensity, float(np.nanmedian(intensity)))
+        cutoff = np.percentile(values[finite], 90.0)
+        fit_mask = finite & (values <= cutoff)
+        if fit_mask.sum() < 3:
+            fit_mask = finite
+        x = sample_x.reshape(-1) / max(width - 1, 1)
+        y = sample_y.reshape(-1) / max(height - 1, 1)
+        design = np.column_stack((x[fit_mask], y[fit_mask], np.ones(fit_mask.sum())))
+        coefficients, *_ = np.linalg.lstsq(design, values[fit_mask], rcond=None)
+        full_y, full_x = np.mgrid[0:height, 0:width]
+        plane = (
+            coefficients[0] * (full_x / max(width - 1, 1))
+            + coefficients[1] * (full_y / max(height - 1, 1))
+            + coefficients[2]
+        )
+        return np.maximum(plane.astype(np.float32), 1.0 / 65535.0)
 
     def preview(
         self,
@@ -277,9 +269,10 @@ class QuickEnhancer:
                     'high_percentile': settings.high_percentile,
                 },
                 'gamma': {'enabled': settings.gamma != 1.0, 'value': settings.gamma},
-                'background_correction': {
-                    'enabled': settings.background_enabled,
-                    'sigma': settings.background_sigma,
+                'illumination_correction': {
+                    'enabled': settings.illumination_correction_enabled,
+                    'method': 'global_plane_normalization',
+                    'fit_excludes_upper_percentile': 10.0,
                 },
                 'denoise': {
                     'enabled': settings.denoise_enabled,
@@ -292,7 +285,6 @@ class QuickEnhancer:
 
     def export_file(self, source_path: str | pathlib.Path, settings: QuickEnhanceSettings) -> dict:
         source_path = pathlib.Path(source_path)
-        settings, _ = self.settings_for_source(source_path, settings)
         image, significant_bits = image_utils.load_pixels(source_path)
         output = self.apply(image, settings, significant_bits)
         output_path = self._next_output_path(source_path)
@@ -302,9 +294,7 @@ class QuickEnhancer:
         temp_recipe = recipe_path.with_name(f'.{recipe_path.name}.{uuid.uuid4().hex}.tmp')
         try:
             source_metadata = image_utils.read_postproc_input_metadata(source_path) or {}
-            channel = str(
-                source_metadata.get('channel') or self._source_channel(source_path) or 'BF'
-            )
+            channel = str(source_metadata.get('channel') or self._source_channel(source_path) or 'BF')
             metadata = image_utils.build_postproc_output_metadata(
                 input_path=source_path,
                 channel=channel,
@@ -316,7 +306,7 @@ class QuickEnhancer:
                 # display-only component for these composite inputs, so retain
                 # the enhanced RGB data and preserve the Composite metadata.
                 output_for_write = output_for_write[..., :3]
-            if not image_utils.is_tiff(source_path) and output_for_write.ndim == 3:
+            if source_path.suffix.lower() not in ('.tif', '.tiff') and output_for_write.ndim == 3:
                 # cv2 loads PNG/JPEG in BGR(A), whereas TIFF metadata and the
                 # project's TIFF writer are RGB-native. Convert the alpha-free
                 # display payload so a Composite PNG cannot reintroduce RGBA.
@@ -364,8 +354,7 @@ class QuickEnhancer:
         files = sorted(
             path
             for path in folder.iterdir()
-            if path.is_file()
-            and path.suffix.lower() in SUPPORTED_SUFFIXES
+            if path.is_file() and path.suffix.lower() in SUPPORTED_SUFFIXES
             and '_enhanced' not in path.stem.lower()
         )
         created = []

--- a/tests/test_quick_enhance.py
+++ b/tests/test_quick_enhance.py
@@ -10,7 +10,7 @@ import pytest
 import tifffile as tf
 
 from modules import image_utils
-from modules.quick_enhance import QuickEnhanceSettings, QuickEnhancer
+from modules.quick_enhance import QUANTITATIVE_USE_WARNING, QuickEnhanceSettings, QuickEnhancer
 
 
 def _metadata(significant_bits: int, channel: str = 'Green') -> dict:
@@ -61,9 +61,7 @@ def test_apply_preserves_source_dtype_range_and_input(image, significant_bits, m
 
 def test_uniform_image_is_stable_and_does_not_divide_by_zero():
     image = np.full((12, 12), 1000, dtype=np.uint16)
-    result = QuickEnhancer().apply(
-        image, QuickEnhanceSettings.for_preset('Brightfield / Phase'), 12
-    )
+    result = QuickEnhancer().apply(image, QuickEnhanceSettings(), 12)
 
     assert np.array_equal(result, image)
 
@@ -82,6 +80,27 @@ def test_rgb_images_use_one_shared_tone_curve_without_changing_shape_or_dtype():
     assert result.dtype == np.uint8
     assert int(result.min()) >= 0
     assert int(result.max()) <= 255
+
+
+def test_representative_bf_fluorescence_and_composite_exports_preserve_sources(tmp_path):
+    fixtures = {
+        'bf': (np.arange(256, dtype=np.uint16).reshape(16, 16), 'BF', (16, 16)),
+        'green': (np.arange(256, dtype=np.uint16).reshape(16, 16), 'Green', (16, 16, 3)),
+        'composite': (np.dstack([np.arange(256, dtype=np.uint16).reshape(16, 16)] * 3), 'Composite', (16, 16, 3)),
+    }
+    enhancer = QuickEnhancer()
+
+    for name, (pixels, channel, expected_shape) in fixtures.items():
+        source = tmp_path / f'{name}.tif'
+        _write_source(source, pixels, 12, channel=channel)
+        original = source.read_bytes()
+        exported = enhancer.export_file(source, QuickEnhanceSettings())
+        output, bits = image_utils.load_pixels(exported['output_path'], collapse_legacy_false_color=False)
+
+        assert source.read_bytes() == original
+        assert output.shape == expected_shape
+        assert output.dtype == np.uint16
+        assert bits == 12
 
 
 @pytest.mark.parametrize('suffix', ('.png', '.jpg'))
@@ -113,54 +132,29 @@ def test_invalid_settings_are_rejected_before_processing():
         QuickEnhancer().apply(np.ones((4, 4), dtype=np.uint16), settings, 12)
 
 
-def test_presets_are_stable_and_safe():
-    automatic = QuickEnhanceSettings.for_preset('Auto (Recommended)')
-    brightfield = QuickEnhanceSettings.for_preset('Brightfield / Phase')
-    contrast_only = QuickEnhanceSettings.for_preset('Contrast Only')
+def test_quick_enhance_uses_one_fixed_non_ai_recipe():
+    settings = QuickEnhanceSettings()
 
-    assert automatic.background_enabled is False
-    assert automatic.denoise_enabled is False
-    assert automatic.gamma == 1.0
-    assert brightfield.gamma == 0.9
-    assert contrast_only.gamma == 1.0
-    with pytest.raises(ValueError, match='Unknown Quick Enhance preset'):
-        QuickEnhanceSettings.for_preset('Custom')
-
-
-def test_auto_detects_transmitted_bf_from_tiff_name_when_metadata_is_unavailable(tmp_path):
-    source = tmp_path / 'scan_BF.tif'
-    _write_source(source, np.arange(64, dtype=np.uint16).reshape(8, 8), 12, channel='BF')
-
-    settings, description = QuickEnhancer().settings_for_source(
-        source, QuickEnhanceSettings.for_preset('Auto (Recommended)')
-    )
-
-    assert settings.preset == 'Brightfield / Phase'
+    assert settings.illumination_correction_enabled is True
+    assert settings.denoise_enabled is False
     assert settings.gamma == 0.9
-    assert 'BF' in description
 
 
-def test_auto_uses_neutral_levels_for_composite_and_unknown_images(tmp_path):
-    composite = tmp_path / 'composite.tif'
-    _write_source(composite, np.zeros((8, 8, 3), dtype=np.uint16), 12, channel='Composite')
-    unknown = tmp_path / 'untagged.png'
-    assert cv2.imwrite(str(unknown), np.zeros((8, 8, 3), dtype=np.uint8))
-    auto = QuickEnhanceSettings.for_preset('Auto (Recommended)')
+def test_broad_illumination_correction_improves_dim_feature_visibility_without_dark_ring():
+    image = np.full((128, 128), 500, dtype=np.uint16)
+    image[48:80, 48:80] = 560
 
-    composite_settings, composite_description = QuickEnhancer().settings_for_source(composite, auto)
-    unknown_settings, unknown_description = QuickEnhancer().settings_for_source(unknown, auto)
+    result = QuickEnhancer().apply(image, QuickEnhanceSettings(), 12)
 
-    assert composite_settings.preset == 'Auto (Recommended)'
-    assert 'Composite' in composite_description
-    assert unknown_settings.preset == 'Auto (Recommended)'
-    assert 'neutral' in unknown_description
+    assert np.ptp(result) > np.ptp(image)
+    assert int(result[32, 64]) >= int(result[8, 8])
 
 
-def test_background_correction_never_wraps_unsigned_values():
+def test_illumination_correction_never_wraps_unsigned_values():
     image = np.zeros((64, 64), dtype=np.uint16)
     image[:, 32:] = 100
     image[20:30, 20:30] = 1000
-    settings = QuickEnhanceSettings(background_enabled=True, background_sigma=5.0)
+    settings = QuickEnhanceSettings(illumination_correction_enabled=True)
 
     result = QuickEnhancer().apply(image, settings, 12)
 
@@ -196,6 +190,13 @@ def test_recipe_has_required_provenance_and_quantitative_warning(tmp_path):
     assert recipe['quantitative_use_warning']
     assert recipe['input_dtype'] == 'uint16'
     assert recipe['operations']['auto_levels']['enabled'] is True
+    assert recipe['operations']['illumination_correction']['enabled'] is True
+    assert recipe['operations']['illumination_correction']['method'] == 'global_plane_normalization'
+
+
+def test_quantitative_warning_routes_ai_workflows_to_lumaquant_pro():
+    assert 'raw images' in QUANTITATIVE_USE_WARNING.lower()
+    assert 'LumaQuant Pro' in QUANTITATIVE_USE_WARNING
 
 
 def test_export_preserves_tiff_depth_writes_recipe_and_never_overwrites(tmp_path):
@@ -224,9 +225,7 @@ def test_brightfield_tiff_stays_monochrome_and_preserves_payload_depth(tmp_path)
     source_data = np.linspace(0, 4095, 256, dtype=np.uint16).reshape(16, 16)
     _write_source(source, source_data, 12, channel='BF')
 
-    exported = QuickEnhancer().export_file(
-        source, QuickEnhanceSettings.for_preset('Brightfield / Phase')
-    )
+    exported = QuickEnhancer().export_file(source, QuickEnhanceSettings())
     output, significant_bits = image_utils.load_pixels(exported['output_path'])
 
     assert output.ndim == 2
@@ -260,9 +259,7 @@ def test_rgba_composite_exports_as_rgb_without_rejecting_composite_metadata(tmp_
     source_data[..., 3] = 4095
     tf.imwrite(source, source_data, photometric='rgb')
 
-    exported = QuickEnhancer().export_file(
-        source, QuickEnhanceSettings.for_preset('Auto (Recommended)')
-    )
+    exported = QuickEnhancer().export_file(source, QuickEnhanceSettings())
     output, significant_bits = image_utils.load_pixels(
         exported['output_path'], collapse_legacy_false_color=False
     )
@@ -279,9 +276,7 @@ def test_rgba_composite_png_drops_alpha_before_rgb_tiff_export(tmp_path):
     source_data[..., 3] = 255
     assert cv2.imwrite(str(source), source_data)
 
-    exported = QuickEnhancer().export_file(
-        source, QuickEnhanceSettings.for_preset('Auto (Recommended)')
-    )
+    exported = QuickEnhancer().export_file(source, QuickEnhanceSettings())
     output, significant_bits = image_utils.load_pixels(
         exported['output_path'], collapse_legacy_false_color=False
     )
@@ -308,19 +303,17 @@ def test_fluorescence_mono_output_is_false_colored_without_changing_bf_rules(cha
     assert grayscale_bf.ndim == 2
 
 
-def test_green_auto_export_is_rgb_and_a_second_run_keeps_green_detection(tmp_path):
+def test_green_export_is_rgb_and_a_second_run_keeps_green_metadata(tmp_path):
     source = tmp_path / 'green_sample.tiff'
     source_data = np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8)
     _write_source(source, source_data, 12, channel='Green')
     enhancer = QuickEnhancer()
 
-    first = enhancer.export_file(source, QuickEnhanceSettings.for_preset('Auto (Recommended)'))
+    first = enhancer.export_file(source, QuickEnhanceSettings())
     output, significant_bits = image_utils.load_pixels(
         first['output_path'], collapse_legacy_false_color=False
     )
-    settings, detection = enhancer.settings_for_source(
-        first['output_path'], QuickEnhanceSettings.for_preset('Auto (Recommended)')
-    )
+    metadata = image_utils.read_postproc_input_metadata(first['output_path'])
 
     assert output.shape == (8, 8, 3)
     assert output.dtype == np.uint16
@@ -328,8 +321,7 @@ def test_green_auto_export_is_rgb_and_a_second_run_keeps_green_detection(tmp_pat
     assert output[..., 1].any()
     assert not output[..., 0].any()
     assert not output[..., 2].any()
-    assert settings.preset == 'Auto (Recommended)'
-    assert 'Green' in detection
+    assert metadata['channel'] == 'Green'
 
 
 def test_folder_batch_skips_unreadable_file_and_continues(tmp_path):
@@ -342,9 +334,7 @@ def test_folder_batch_skips_unreadable_file_and_continues(tmp_path):
     result = QuickEnhancer().export_folder(
         tmp_path,
         QuickEnhanceSettings(),
-        progress_callback=lambda completed, total, path: progress.append(
-            (completed, total, path.name)
-        ),
+        progress_callback=lambda completed, total, path: progress.append((completed, total, path.name)),
     )
 
     assert result['status'] is True
@@ -358,7 +348,9 @@ def test_folder_batch_skips_unreadable_file_and_continues(tmp_path):
 def test_mixed_folder_exports_bf_composite_png_jpeg_and_skips_bad_or_derived_files(tmp_path):
     bf = tmp_path / 'bf.tif'
     composite = tmp_path / 'composite.tif'
-    _write_source(bf, np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8), 12, channel='BF')
+    _write_source(
+        bf, np.linspace(0, 4095, 64, dtype=np.uint16).reshape(8, 8), 12, channel='BF'
+    )
     composite_pixels = np.zeros((8, 8, 3), dtype=np.uint16)
     composite_pixels[..., 0] = 4095
     composite_pixels[..., 1] = 1200
@@ -372,28 +364,20 @@ def test_mixed_folder_exports_bf_composite_png_jpeg_and_skips_bad_or_derived_fil
     bad.write_bytes(b'not an image')
     existing_derived = tmp_path / 'old_enhanced.tif'
     _write_source(existing_derived, np.ones((8, 8), dtype=np.uint16), 12, channel='BF')
-    original_bytes = {
-        path: path.read_bytes() for path in (bf, composite, png, jpeg, bad, existing_derived)
-    }
+    original_bytes = {path: path.read_bytes() for path in (bf, composite, png, jpeg, bad, existing_derived)}
     progress = []
 
     result = QuickEnhancer().export_folder(
         tmp_path,
         QuickEnhanceSettings(),
-        progress_callback=lambda completed, total, path: progress.append(
-            (completed, total, path.name)
-        ),
+        progress_callback=lambda completed, total, path: progress.append((completed, total, path.name)),
     )
 
     assert result['total'] == 5
     assert result['created_count'] == 4
     assert [entry['source_path'].name for entry in result['skipped']] == ['bad.tif']
     assert [(completed, total) for completed, total, _ in progress] == [
-        (1, 5),
-        (2, 5),
-        (3, 5),
-        (4, 5),
-        (5, 5),
+        (1, 5), (2, 5), (3, 5), (4, 5), (5, 5)
     ]
     assert all(path.read_bytes() == original for path, original in original_bytes.items())
     assert (tmp_path / 'bf_enhanced.tif').exists()
@@ -419,44 +403,28 @@ def test_ui_export_callback_restores_controls_on_every_terminal_path():
     """The popup wrapper binds ``done`` and failure must clear ``busy``."""
     source = (pathlib.Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text()
     tree = ast.parse(source)
-    cls = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == 'QuickEnhanceControls'
-    )
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == 'QuickEnhanceControls')
     assert any(
         isinstance(node, ast.Assign)
         and any(isinstance(target, ast.Name) and target.id == 'done' for target in node.targets)
         for node in cls.body
     )
     callback = next(
-        node
-        for node in cls.body
-        if isinstance(node, ast.FunctionDef) and node.name == '_export_callback'
+        node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == '_export_callback'
     )
     callback_source = ast.get_source_segment(source, callback)
-    # busy belongs to the preview path (set/cleared there); the export
-    # path gates on _export_inflight alone, which must clear on every
-    # terminal path so the export button re-enables.
+    assert 'self.busy = False' in callback_source
     assert 'self._export_inflight = False' in callback_source
 
 
 def test_refresh_preview_requests_the_rebuilding_status():
     source = (pathlib.Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text()
     tree = ast.parse(source)
-    cls = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == 'QuickEnhanceControls'
-    )
-    refresh = next(
-        node
-        for node in cls.body
-        if isinstance(node, ast.FunctionDef) and node.name == 'refresh_preview'
-    )
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == 'QuickEnhanceControls')
+    refresh = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == 'refresh_preview')
 
     assert 'refresh=True' in ast.get_source_segment(source, refresh)
-    assert "'Updating preview...' if refresh" in source
+    assert "'Updating preview…' if refresh" in source
 
 
 def test_preview_worker_imports_the_fluorescence_channel_helper():

--- a/tests/test_quick_enhance_kv.py
+++ b/tests/test_quick_enhance_kv.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import subprocess
 import sys
 
+
 KV_PATH = Path(__file__).resolve().parents[1] / 'ui' / 'lumaviewpro.kv'
 
 # The five named post-processing panel rules (Object Analysis is an inline
@@ -43,36 +44,27 @@ def test_lumaviewpro_kv_parses_with_quick_enhance_controls():
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_quick_enhance_kv_uses_short_labels_without_custom_controls():
-    kv_path = Path(__file__).resolve().parents[1] / 'ui' / 'lumaviewpro.kv'
-    content = kv_path.read_text(encoding='utf-8')
-    quick_enhance_rule = content[
-        content.index('<QuickEnhanceControls>:') : content.index('<QuickEnhanceUtilityButton@')
-    ]
+def test_quick_enhance_kv_offers_one_fixed_quick_enhance_action():
+    content = KV_PATH.read_text(encoding='utf-8')
+    quick_enhance_rule = content[content.index('<QuickEnhanceControls>:'):content.index('<QuickEnhanceUtilityButton@')]
 
-    assert (
-        "values: ('Auto (Recommended)', 'Brightfield / Phase', 'Contrast Only')"
-        in quick_enhance_rule
-    )
     assert "text: 'Choose Image'" in quick_enhance_rule
     assert "text: 'Choose Folder'" in quick_enhance_rule
     assert "text: 'Show Original' if root.show_after else 'Show Enhanced'" in quick_enhance_rule
     assert "text: 'Update Preview'" in quick_enhance_rule
-    assert "text: 'Save Folder' if root.source_folder else 'Save Image'" in quick_enhance_rule
-    assert "text: 'Run'" in quick_enhance_rule
+    assert "text: 'Quick Enhance Folder' if root.source_folder else 'Quick Enhance Image'" in quick_enhance_rule
+    assert "text: 'Quick Enhance'" in quick_enhance_rule
     assert 'disabled: not root.input_ready' in quick_enhance_rule
-    assert 'Custom' not in quick_enhance_rule
+    assert 'Spinner:' not in quick_enhance_rule
+    assert 'text: root.warning_text' in quick_enhance_rule
+    assert "height: max(dp(66), self.texture_size[1] + dp(12))" in quick_enhance_rule
+    assert "height: max(dp(78), self.texture_size[1] + dp(12))" in quick_enhance_rule
 
 
 def test_every_post_processing_panel_is_scroll_wrapped():
-    """Structural guard for panel clipping: the accordion viewport is
-    shorter than several panels at the 1024x600 minimum window, so every
-    AccordionItem's first child widget must be the shared scroll wrapper.
-    A future panel added without it fails here instead of silently
-    clipping its lower controls."""
+    """Guard against controls clipping at the minimum application window size."""
     content = KV_PATH.read_text(encoding='utf-8')
     lines = _rule_block(content, '<PostProcessingAccordion>:').splitlines()
-
     item_indices = [i for i, ln in enumerate(lines) if ln.strip() == 'AccordionItem:']
     assert len(item_indices) >= 6, 'expected the six post-processing accordion items'
 
@@ -88,17 +80,10 @@ def test_every_post_processing_panel_is_scroll_wrapped():
             if re.match(r'^[A-Z]\w*:$', stripped):
                 first_child_widget = stripped[:-1]
                 break
-        assert first_child_widget == 'PostProcessingPanelScroll', (
-            f'AccordionItem at kv line offset {idx} hosts {first_child_widget!r} '
-            f'directly; every panel must sit inside PostProcessingPanelScroll '
-            f'or its lower controls clip at the minimum window size'
-        )
+        assert first_child_widget == 'PostProcessingPanelScroll'
 
 
 def test_panel_rules_declare_their_own_minimum_height():
-    """The wrapper only scrolls a panel that reports its content height:
-    each named panel rule must be self-describing (size_hint_y None +
-    minimum_height), so any future instantiation scrolls correctly."""
     content = KV_PATH.read_text(encoding='utf-8')
     for header in PANEL_RULE_HEADERS:
         block = _rule_block(content, header)
@@ -109,33 +94,22 @@ def test_panel_rules_declare_their_own_minimum_height():
 
 
 def test_quick_enhance_disclaimer_is_single_homed():
-    """The disclaimer's string store is QUANTITATIVE_USE_WARNING; the kv
-    caption REFLECTS it (root.warning_text) rather than duplicating the
-    words, and no status-line append re-introduces a second rendering.
-    Also guards the literal backslash-n regression: the old duplicated
-    caption text carried an escaped newline that rendered as characters."""
     kv_rule = _rule_block(KV_PATH.read_text(encoding='utf-8'), '<QuickEnhanceControls>:')
-    assert 'text: root.warning_text' in kv_rule, 'caption must reflect the warning store'
-    assert '\\n' not in kv_rule, 'no escaped-newline literals in the Quick Enhance rule'
-    assert 'visual inspection' not in kv_rule, 'disclaimer text must not be duplicated in kv'
+    assert 'text: root.warning_text' in kv_rule
+    assert '\\n' not in kv_rule
+    assert 'visual inspection' not in kv_rule
 
     py_src = (Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text(
         encoding='utf-8'
     )
-    occurrences = py_src.count('QUANTITATIVE_USE_WARNING')
-    assert occurrences == 2, (
-        f'QUANTITATIVE_USE_WARNING must appear exactly twice in ui/post_processing.py '
-        f'(import + warning_text attribute); found {occurrences} -- a status-text '
-        f'append duplicating the caption has likely been re-introduced'
-    )
+    assert py_src.count('QUANTITATIVE_USE_WARNING') == 2
 
 
-def test_quick_enhance_documentation_explains_the_short_mode_names():
-    documentation = (Path(__file__).resolve().parents[1] / 'docs' / 'QUICK_ENHANCE.md').read_text(
-        encoding='utf-8'
-    )
+def test_quick_enhance_documentation_explains_the_fixed_recipe():
+    documentation = (
+        Path(__file__).resolve().parents[1] / 'docs' / 'QUICK_ENHANCE.md'
+    ).read_text(encoding='utf-8')
 
-    assert '## Modes' in documentation
-    assert 'Auto (Recommended)' in documentation
-    assert 'Brightfield / Phase' in documentation
-    assert 'Contrast Only' in documentation
+    assert 'illumination correction' in documentation
+    assert 'dark halos' in documentation
+    assert 'AI denoising' in documentation

--- a/ui/lumaviewpro.kv
+++ b/ui/lumaviewpro.kv
@@ -1769,9 +1769,9 @@
 		text: root.warning_text
 		font_size: '11sp'
 		color: 0.86, 0.91, 0.95, 1
-		text_size: self.width, None
+		text_size: self.width - dp(16), None
 		size_hint_y: None
-		height: '42dp'
+		height: max(dp(66), self.texture_size[1] + dp(12))
 
 	Label:
 		text: 'Input'
@@ -1790,22 +1790,18 @@
 			text: 'Choose Folder'
 			on_release: self.choose('apply_quick_enhance_to_folder')
 	Label:
-		text: 'Run'
+		text: 'Quick Enhance'
 		font_size: '12sp'
 		bold: True
 		color: 0.96, 0.98, 1, 1
 		size_hint_y: None
 		height: '18dp'
-	Spinner:
-		id: quick_enhance_preset
-		text: root.preset
-		values: ('Auto (Recommended)', 'Brightfield / Phase', 'Contrast Only')
+	Label:
+		text: 'Global illumination correction + contrast for visual review'
+		font_size: '10sp'
+		color: 0.86, 0.91, 0.95, 1
 		size_hint_y: None
-		height: '36dp'
-		background_normal: ''
-		background_color: 0.18, 0.25, 0.31, 1
-		color: 1, 1, 1, 1
-		on_text: root.preset = self.text
+		height: '24dp'
 	BoxLayout:
 		size_hint_y: None
 		height: '36dp'
@@ -1825,7 +1821,7 @@
 		size_hint_y: None
 		height: '18dp'
 	QuickEnhancePrimaryButton:
-		text: 'Save Folder' if root.source_folder else 'Save Image'
+		text: 'Quick Enhance Folder' if root.source_folder else 'Quick Enhance Image'
 		size_hint_y: None
 		height: '38dp'
 		disabled: not root.input_ready
@@ -1833,9 +1829,9 @@
 	Label:
 		text: root.status_text
 		font_size: '10sp'
-		text_size: self.width, None
+		text_size: self.width - dp(16), None
 		size_hint_y: None
-		height: '54dp'
+		height: max(dp(78), self.texture_size[1] + dp(12))
 		halign: 'left'
 		valign: 'middle'
 	QuickEnhanceUtilityButton:

--- a/ui/post_processing.py
+++ b/ui/post_processing.py
@@ -48,7 +48,6 @@ class QuickEnhanceControls(BoxLayout):
     warning_text = QUANTITATIVE_USE_WARNING
 
     done = BooleanProperty(False)
-    preset = StringProperty('Auto (Recommended)')
     source_path = StringProperty('')
     source_folder = StringProperty('')
     last_output_folder = StringProperty('')
@@ -72,7 +71,7 @@ class QuickEnhanceControls(BoxLayout):
         self.source_folder = ''
         self.input_ready = False
         self.busy = True
-        self.status_text = 'Updating preview...' if refresh else 'Loading image preview...'
+        self.status_text = 'Updating preview…' if refresh else 'Loading image preview…'
         _app_ctx.ctx.file_io_executor.put(
             IOTask(
                 action=self._load_preview,
@@ -91,10 +90,7 @@ class QuickEnhanceControls(BoxLayout):
         self.status_text = f'Folder selected: {folder.name}. Folder export is ready; preview controls require Select Image.'
 
     def _settings(self) -> QuickEnhanceSettings:
-        return QuickEnhanceSettings.for_preset(self.preset)
-
-    def on_preset(self, *_args) -> None:
-        self.refresh_preview()
+        return QuickEnhanceSettings()
 
     def refresh_preview(self) -> None:
         if not self.source_path or self.busy:
@@ -104,7 +100,6 @@ class QuickEnhanceControls(BoxLayout):
     @staticmethod
     def _load_preview(path: pathlib.Path, settings: QuickEnhanceSettings) -> dict:
         enhancer = QuickEnhancer()
-        settings, detection = enhancer.settings_for_source(path, settings)
         image, significant_bits = image_utils.load_pixels(path)
         before, after = enhancer.preview(image, settings, significant_bits)
         channel = enhancer._source_channel(path)
@@ -119,7 +114,7 @@ class QuickEnhanceControls(BoxLayout):
             'before': before,
             'after': after,
             'significant_bits': significant_bits,
-            'detection': detection,
+            'detection': 'Fixed recipe: global illumination correction, auto levels, and gentle gamma.',
         }
 
     def _preview_callback(self, result=None, exception=None) -> None:
@@ -218,6 +213,7 @@ class QuickEnhanceControls(BoxLayout):
         popup.text = f'Quick Enhance: {completed}/{total} -- {path.name}'
 
     def _export_callback(self, popup, result=None, exception=None) -> None:
+        self.busy = False
         self._export_inflight = False
         from modules.notification_center import notifications
 


### PR DESCRIPTION
## Summary

Adds one fixed, non-AI **Quick Enhance** action for visual inspection.

- Uses global illumination correction, automatic levels, and gentle gamma.
- Avoids local background subtraction that can create dark halos.
- Supports both a selected image and a selected folder.
- Produces derived TIFF exports and recipe JSON files only; raw source files are never overwritten.
- Preserves native TIFF depth and keeps fluorescence/composite export handling intact.
- Adds a clear UI warning directing quantitative or AI-assisted workflows to LumaQuant Pro.
- Keeps the Quick Enhance panel to one action—no modes or sliders.

## Validation

  - Quick Enhance processing, folder batching, TIFF/PNG/JPEG export, source preservation, metadata/recipe output, UI wiring, KV parsing, and image utility coverage.
  - preserved all source bytes
  - retained 12-bit TIFF depth
- Controlled visual checks:
  - reduced uneven illumination in a synthetic field
  - no dark-halo signal in smooth and noisy synthetic feature checks

## Scope / scientific boundary

Quick Enhance is a display-oriented classical enhancement, not validated restoration or a quantitative-analysis path. Use raw images for quantification; use LumaQuant Pro for AI-assisted validated enhancement workflows.