### PR TITLE
Improve Enhance workflow and explain unsupported stitch sources

### DIFF
--- a/docs/QUICK_ENHANCE.md
+++ b/docs/QUICK_ENHANCE.md
@@ -4,10 +4,9 @@ Quick Enhance creates a derived TIFF for visual inspection. It never changes the
 
 ## Use it
 
-1. Choose Image to inspect and save one image, or Choose Folder to save every supported image in that folder.
-2. Select Quick Enhance Image or Quick Enhance Folder. Use Show Output Folder when complete.
-
-Choose Image enables Before / After and Update Preview. A folder is a batch operation, so it has no single-image preview.
+1. Select **Enhance**.
+2. In the native picker, choose either one supported image or a folder.
+3. Enhancement starts immediately. Every output is saved as a derived TIFF, and the main viewer briefly shows each completed image. The panel reports `Image x of y` while a folder runs, then the saved output path.
 
 ## Fixed recipe
 
@@ -18,8 +17,6 @@ Quick Enhance applies the same non-AI recipe to every selected image:
 
 This is classical presentation processing, not AI denoising or restoration. LumaQuant Pro remains the separate AI-assisted cleanup workflow.
 
-## Buttons
+## Progress
 
-- **Before / After** switches the single-image preview between the source and its enhanced version.
-- **Update Preview** redraws the single-image preview using the selected mode.
-- **Show Output Folder** opens the folder containing the most recently saved derived TIFFs.
+Folder processing runs one image at a time. Unsupported or unreadable images are skipped; source images and prior derived outputs are never overwritten.

--- a/docs/STITCHING.md
+++ b/docs/STITCHING.md
@@ -1,0 +1,13 @@
+# Stitching
+
+## Fast Preview Stitch
+
+Fast Preview Stitch is for a quick visual check of tile placement and coverage. When the stage metadata indicates real overlap, it uses bounded FFT phase correlation to estimate the local offset. It is faster, but can be less reliable on weak, repetitive, or low-detail overlap.
+
+## Quality Stitch
+
+Quality Stitch is for the final derived mosaic. With the same real overlap, it uses the recorded stage geometry plus bounded local normalized cross-correlation (NCC), which searches the plausible local offset more carefully. It is slower and is expected to produce more reliable alignment when tile content makes registration difficult.
+
+## Important behavior
+
+Both modes first infer overlap from the recorded stage positions. If that inference is 0% overlap, neither mode attempts image registration: both place tiles from stage geometry and preserve source pixels and channel colors. Fast Preview therefore does know when real overlap exists; it uses the same stage-derived overlap decision as Quality, but applies the faster FFT registration route instead of the more careful NCC route.

--- a/lumaviewpro.py
+++ b/lumaviewpro.py
@@ -375,7 +375,7 @@ from modules.app_config import (
 # .per-file-ignores] "lumaviewpro.py" lists F401) silences that. Do not remove
 # any of these without first grepping ui/*.kv for the class name.
 from ui.composite_capture import CompositeCapture
-from ui.file_dialogs import FileChooseBTN, FileSaveBTN, FolderChooseBTN
+from ui.file_dialogs import FileChooseBTN, FileOrFolderChooseBTN, FileSaveBTN, FolderChooseBTN
 from ui.histogram import Histogram
 from ui.image_settings import (
     AccordionItemImageSettingsBase,

--- a/modules/protocol_post_processor.py
+++ b/modules/protocol_post_processor.py
@@ -181,14 +181,23 @@ class ProtocolPostProcessor(abc.ABC):
         # tifffile, which cannot decode JPG. A scan saved as JPG has no
         # re-readable source for these outputs, so stop here with a clear
         # message instead of letting tifffile raise partway through a group.
-        source_suffixes = {pathlib.Path(str(fp)).suffix.lower() for fp in df['Filepath']}
-        if source_suffixes and source_suffixes.isdisjoint(image_utils.TIFF_SUFFIXES):
+        unsupported_source = next(
+            (
+                pathlib.Path(str(filepath))
+                for filepath in df['Filepath']
+                if pathlib.Path(str(filepath)).suffix.lower() not in image_utils.TIFF_SUFFIXES
+            ),
+            None,
+        )
+        if unsupported_source is not None:
+            source_format = unsupported_source.suffix.lstrip('.').upper() or 'unknown'
             return {
                 'status': False,
+                'reason': 'unsupported_source_format',
                 'message': (
-                    'Composite, stitch, and z-projection require TIFF or '
-                    'OME-TIFF source images. This scan was saved as JPG, '
-                    'which cannot be re-read for post-processing.'
+                    f'{self._post_function.value} requires TIFF or OME-TIFF source images. '
+                    f'First unsupported {source_format} file: {unsupported_source.name}. '
+                    'Reacquire the scan as TIFF or OME-TIFF before post-processing.'
                 ),
             }
 

--- a/modules/quick_enhance.py
+++ b/modules/quick_enhance.py
@@ -289,7 +289,12 @@ class QuickEnhancer:
             'quantitative_use_warning': QUANTITATIVE_USE_WARNING,
         }
 
-    def export_file(self, source_path: str | pathlib.Path, settings: QuickEnhanceSettings) -> dict:
+    def export_file(
+        self,
+        source_path: str | pathlib.Path,
+        settings: QuickEnhanceSettings,
+        display_callback: Callable[[np.ndarray, int], None] | None = None,
+    ) -> dict:
         source_path = pathlib.Path(source_path)
         image, significant_bits = image_utils.load_pixels(source_path)
         output = self.apply(image, settings, significant_bits)
@@ -350,6 +355,12 @@ class QuickEnhancer:
                     logger.warning('[QuickEnhance] Could not remove temporary file %s', temporary)
             raise
 
+        if display_callback is not None:
+            try:
+                display_callback(output_for_write, significant_bits)
+            except Exception:
+                logger.warning('[QuickEnhance] Could not queue derived image for display', exc_info=True)
+
         return {'source_path': source_path, 'output_path': output_path, 'recipe_path': recipe_path}
 
     def export_folder(
@@ -357,6 +368,7 @@ class QuickEnhancer:
         folder: str | pathlib.Path,
         settings: QuickEnhanceSettings,
         progress_callback: Callable[[int, int, pathlib.Path], None] | None = None,
+        display_callback: Callable[[np.ndarray, int], None] | None = None,
     ) -> dict:
         folder = pathlib.Path(folder)
         files = sorted(
@@ -371,7 +383,13 @@ class QuickEnhancer:
         total = len(files)
         for completed, source_path in enumerate(files, start=1):
             try:
-                created.append(self.export_file(source_path, settings))
+                created.append(
+                    self.export_file(
+                        source_path,
+                        settings,
+                        display_callback=display_callback,
+                    )
+                )
             except (OSError, ValueError, cv2.error, MemoryError) as exc:
                 logger.warning('[QuickEnhance] Skipping %s: %s', source_path, exc, exc_info=True)
                 skipped.append({'source_path': source_path, 'error': str(exc)})

--- a/tests/test_enhance_file_or_folder.py
+++ b/tests/test_enhance_file_or_folder.py
@@ -26,6 +26,20 @@ def test_macos_enhance_picker_accepts_a_file_or_folder_in_one_native_dialog():
     assert 'choose file or folder' in ast.get_source_segment(source, method)
 
 
+def test_non_macos_enhance_picker_offers_both_native_target_kinds():
+    source = (REPO / 'ui' / 'file_dialogs.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    method = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == '_platform_native_choose_file_or_folder'
+    )
+    body = ast.get_source_segment(source, method)
+    assert 'askyesnocancel' in body
+    assert 'askopenfilename' in body
+    assert 'askdirectory' in body
+
+
 def test_enhance_picker_routes_files_and_folders_after_the_protocol_guard():
     body = _class_method_source('ui/file_dialogs.py', 'FileOrFolderChooseBTN', 'on_selection_function')
     guard_idx = body.find('protocol_running.is_set')
@@ -44,3 +58,27 @@ def test_enhance_progress_is_counted_and_each_saved_image_reaches_the_main_viewe
     viewer_method = _class_method_source('ui/scope_display.py', 'ScopeDisplay', 'hold_derived_image')
     assert 'image_to_texture' in viewer_method
     assert 'bump_protocol_hold' in viewer_method
+
+
+def test_stitching_manual_matches_the_stage_constrained_mode_router():
+    manual = (REPO / 'docs' / 'STITCHING.md').read_text(encoding='utf-8')
+    router = (REPO / 'modules' / 'stitching_core.py').read_text(encoding='utf-8')
+
+    for phrase in ('FFT phase correlation', 'normalized cross-correlation', '0% overlap'):
+        assert phrase in manual
+    assert "mode == 'fast_preview'" in router
+    assert 'fft_phase_stitcher' in router
+    assert 'overlap_stitcher' in router
+    assert 'stage_position_stitcher' in router
+
+
+def test_application_registers_the_one_click_picker_and_manual_matches_stitch_router():
+    app_source = (REPO / 'lumaviewpro.py').read_text(encoding='utf-8')
+    assert 'FileOrFolderChooseBTN' in app_source
+
+    manual = (REPO / 'docs' / 'STITCHING.md').read_text(encoding='utf-8')
+    router = (REPO / 'modules' / 'stitching_core.py').read_text(encoding='utf-8')
+    assert 'FFT phase correlation' in manual
+    assert 'normalized cross-correlation' in manual
+    assert "mode == 'fast_preview'" in router
+    assert 'quality_local_ncc' in router

--- a/tests/test_enhance_file_or_folder.py
+++ b/tests/test_enhance_file_or_folder.py
@@ -1,0 +1,46 @@
+"""One-click Enhance picker and central-viewer handoff regression guards."""
+
+import ast
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _class_method_source(path, class_name, method_name):
+    source = (REPO / path).read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name)
+    method = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == method_name)
+    return ast.get_source_segment(source, method)
+
+
+def test_macos_enhance_picker_accepts_a_file_or_folder_in_one_native_dialog():
+    source = (REPO / 'ui' / 'file_dialogs.py').read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    method = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == '_macos_choose_file_or_folder'
+    )
+    assert 'choose file or folder' in ast.get_source_segment(source, method)
+
+
+def test_enhance_picker_routes_files_and_folders_after_the_protocol_guard():
+    body = _class_method_source('ui/file_dialogs.py', 'FileOrFolderChooseBTN', 'on_selection_function')
+    guard_idx = body.find('protocol_running.is_set')
+    folder_idx = body.find('path.is_dir')
+    file_idx = body.find('path.is_file')
+    assert guard_idx != -1 and guard_idx < folder_idx < file_idx
+    assert 'set_source_folder' in body
+    assert 'set_source_file' in body
+
+
+def test_enhance_progress_is_counted_and_each_saved_image_reaches_the_main_viewer():
+    post_processing = (REPO / 'ui' / 'post_processing.py').read_text(encoding='utf-8')
+    assert "f'Image {completed} of {total}'" in post_processing
+    assert 'hold_derived_image' in post_processing
+
+    viewer_method = _class_method_source('ui/scope_display.py', 'ScopeDisplay', 'hold_derived_image')
+    assert 'image_to_texture' in viewer_method
+    assert 'bump_protocol_hold' in viewer_method

--- a/tests/test_issue_693_jpg_protocol_format.py
+++ b/tests/test_issue_693_jpg_protocol_format.py
@@ -122,8 +122,25 @@ def test_composite_rejects_jpg_source_with_clear_message():
     _stub_helper(comp, df)
     result = comp.load_folder(path='run', tiling_configs_file_loc=pathlib.Path('tiling.json'))
     assert result['status'] is False
+    assert result['reason'] == 'unsupported_source_format'
     assert 'JPG' in result['message']
     assert 'TIFF' in result['message']
+    assert 'A1_Green_0000.jpg' in result['message']
+
+
+def test_mixed_tiff_and_jpg_rejects_the_first_unsupported_source():
+    comp = _make_composite()
+    df = pd.DataFrame(
+        {'Filepath': ['A1_Green_0000.tiff', 'A1_Red_0000.jpg', 'A1_Blue_0000.jpg']}
+    )
+    _stub_helper(comp, df)
+
+    result = comp.load_folder(path='run', tiling_configs_file_loc=pathlib.Path('tiling.json'))
+
+    assert result['status'] is False
+    assert result['reason'] == 'unsupported_source_format'
+    assert 'A1_Red_0000.jpg' in result['message']
+    assert 'A1_Blue_0000.jpg' not in result['message']
 
 
 def test_composite_does_not_trip_guard_for_tiff_source():

--- a/tests/test_issue_750_native_dialog_async.py
+++ b/tests/test_issue_750_native_dialog_async.py
@@ -41,6 +41,7 @@ _TREE = ast.parse(_SRC)
 _PRIMITIVE_NAMES = {
     '_foregrounded_tk_root',
     '_platform_native_choose_folder',
+    '_platform_native_choose_file_or_folder',
     '_platform_native_open_file',
     '_platform_native_save_file',
 }
@@ -145,7 +146,7 @@ def test_macos_primitives_use_the_zombie_backstop_timeout():
     """The osascript timeout is the shared hour-long backstop, not a short
     user-facing limit that silently cancels a legitimately-open panel."""
     assert 'timeout=120' not in _SRC
-    assert _SRC.count('timeout=_MACOS_DIALOG_TIMEOUT_S') == 3
+    assert _SRC.count('timeout=_MACOS_DIALOG_TIMEOUT_S') == 4
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_quick_enhance.py
+++ b/tests/test_quick_enhance.py
@@ -407,11 +407,15 @@ def test_mixed_folder_exports_bf_composite_png_jpeg_and_skips_bad_or_derived_fil
     }
     progress = []
 
+    displayed = []
     result = QuickEnhancer().export_folder(
         tmp_path,
         QuickEnhanceSettings(),
         progress_callback=lambda completed, total, path: progress.append(
             (completed, total, path.name)
+        ),
+        display_callback=lambda image, significant_bits: displayed.append(
+            (image.shape, significant_bits)
         ),
     )
 
@@ -430,6 +434,7 @@ def test_mixed_folder_exports_bf_composite_png_jpeg_and_skips_bad_or_derived_fil
     assert (tmp_path / 'composite_enhanced.tif').exists()
     assert (tmp_path / 'share_enhanced.tif').exists()
     assert (tmp_path / 'share_enhanced_2.tif').exists()
+    assert len(displayed) == 4
 
 
 def test_output_folder_is_reported_from_a_completed_export(tmp_path):
@@ -446,12 +451,7 @@ def test_output_folder_is_reported_from_a_completed_export(tmp_path):
 
 
 def test_ui_export_callback_restores_controls_on_every_terminal_path():
-    """The popup wrapper binds ``done``; ``_export_inflight`` must clear
-    UNCONDITIONALLY at the top of ``_export_callback`` so the export button
-    re-enables on success and failure alike. ``busy`` is preview-owned
-    (``set_source_file`` sets it, ``_preview_callback`` clears it) and must
-    never be written here: an export completing while a preview loads would
-    re-enable the whole panel mid-load and allow overlapping preview tasks."""
+    """Automatic Enhance owns ``busy`` for the complete export lifetime."""
     source = (pathlib.Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text()
     tree = ast.parse(source)
     cls = next(
@@ -485,20 +485,17 @@ def test_ui_export_callback_restores_controls_on_every_terminal_path():
             and target.value.id == 'self'
         ]
 
-    busy_writes = [node.lineno for node in ast.walk(callback) if 'busy' in _self_attr_targets(node)]
-    assert busy_writes == [], (
-        f'_export_callback must not write the preview-owned busy flag (lines {busy_writes})'
-    )
-    assert any(
-        '_export_inflight' in _self_attr_targets(stmt)
-        and isinstance(stmt, ast.Assign)
-        and isinstance(stmt.value, ast.Constant)
-        and stmt.value.value is False
-        for stmt in callback.body
-    ), '_export_inflight = False must be an unconditional top-level statement of _export_callback'
+    for attr in ('_export_inflight', 'busy'):
+        assert any(
+            attr in _self_attr_targets(stmt)
+            and isinstance(stmt, ast.Assign)
+            and isinstance(stmt.value, ast.Constant)
+            and stmt.value.value is False
+            for stmt in callback.body
+        ), f'{attr} = False must be an unconditional top-level statement of _export_callback'
 
 
-def test_refresh_preview_requests_the_rebuilding_status():
+def test_file_and_folder_selection_start_enhance_automatically():
     source = (pathlib.Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text()
     tree = ast.parse(source)
     cls = next(
@@ -506,17 +503,8 @@ def test_refresh_preview_requests_the_rebuilding_status():
         for node in tree.body
         if isinstance(node, ast.ClassDef) and node.name == 'QuickEnhanceControls'
     )
-    refresh = next(
-        node
-        for node in cls.body
-        if isinstance(node, ast.FunctionDef) and node.name == 'refresh_preview'
-    )
-
-    assert 'refresh=True' in ast.get_source_segment(source, refresh)
-    assert "'Updating preview...' if refresh" in source
-
-
-def test_preview_worker_imports_the_fluorescence_channel_helper():
-    source = (pathlib.Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text()
-
-    assert 'from modules import common_utils' in source
+    for method in ('set_source_file', 'set_source_folder'):
+        body = next(
+            node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == method
+        )
+        assert '_start_export' in ast.get_source_segment(source, body)

--- a/tests/test_quick_enhance_kv.py
+++ b/tests/test_quick_enhance_kv.py
@@ -44,31 +44,25 @@ def test_lumaviewpro_kv_parses_with_quick_enhance_controls():
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_quick_enhance_kv_offers_one_fixed_quick_enhance_action():
+def test_quick_enhance_kv_offers_one_click_enhance_without_panel_prose():
     content = KV_PATH.read_text(encoding='utf-8')
     quick_enhance_rule = content[
         content.index('<QuickEnhanceControls>:') : content.index('<QuickEnhanceUtilityButton@')
     ]
 
-    assert "text: 'Choose Image'" in quick_enhance_rule
-    assert "text: 'Choose Folder'" in quick_enhance_rule
-    assert "text: 'Show Original' if root.show_after else 'Show Enhanced'" in quick_enhance_rule
-    assert "text: 'Update Preview'" in quick_enhance_rule
-    assert "text: 'Save Enhanced Image'" in quick_enhance_rule
-    assert quick_enhance_rule.count("text: 'Quick Enhance'") == 1
-    assert "text: 'Save'" not in quick_enhance_rule
-    assert 'Global illumination correction + contrast for visual review' not in quick_enhance_rule
-    assert 'disabled: not root.input_ready' in quick_enhance_rule
-    assert 'Spinner:' not in quick_enhance_rule
-    assert 'text: root.warning_text' in quick_enhance_rule
+    assert quick_enhance_rule.count('FileOrFolderChooseBTN:') == 1
+    assert "text: 'Enhance'" in quick_enhance_rule
+    assert 'text: root.status_text' in quick_enhance_rule
+    for removed in (
+        "text: 'Choose Image'",
+        "text: 'Choose Folder'",
+        "text: 'Quick Enhance'",
+        "text: 'Save Enhanced Image'",
+        'text: root.warning_text',
+        'quick_enhance_preview_image',
+    ):
+        assert removed not in quick_enhance_rule
     assert 'height: self.texture_size[1] + dp(12)' in quick_enhance_rule
-
-    preview_index = quick_enhance_rule.index('id: quick_enhance_preview_image')
-    save_index = quick_enhance_rule.index("text: 'Save Enhanced Image'")
-    status_index = quick_enhance_rule.index('text: root.status_text')
-    output_folder_index = quick_enhance_rule.index("text: 'Show Output Folder'")
-    assert preview_index < save_index, 'preview must be visible before export controls'
-    assert output_folder_index < status_index, 'status belongs at the bottom of the panel'
 
 
 def test_every_post_processing_panel_is_scroll_wrapped():
@@ -103,16 +97,14 @@ def test_panel_rules_declare_their_own_minimum_height():
         )
 
 
-def test_quick_enhance_disclaimer_is_single_homed():
+def test_quick_enhance_disclaimer_is_not_rendered_in_the_panel():
     kv_rule = _rule_block(KV_PATH.read_text(encoding='utf-8'), '<QuickEnhanceControls>:')
-    assert 'text: root.warning_text' in kv_rule
-    assert '\\n' not in kv_rule
-    assert 'visual inspection' not in kv_rule
+    assert 'warning_text' not in kv_rule
 
     py_src = (Path(__file__).resolve().parents[1] / 'ui' / 'post_processing.py').read_text(
         encoding='utf-8'
     )
-    assert py_src.count('QUANTITATIVE_USE_WARNING') == 2
+    assert 'QUANTITATIVE_USE_WARNING' not in py_src
 
 
 def test_quick_enhance_documentation_explains_the_fixed_recipe():

--- a/tests/test_stitcher.py
+++ b/tests/test_stitcher.py
@@ -517,7 +517,7 @@ class TestSimplePositionStitcher:
         assert 'geometry-only fallback' in branch_source
         assert 'popup.text' in branch_source
 
-    def test_stitcher_popup_never_surfaces_raw_worker_message(self):
+    def test_stitcher_popup_surfaces_only_the_structured_unsupported_format_message(self):
         source = (
             pathlib.Path(__file__).resolve().parent.parent / 'ui' / 'post_processing.py'
         ).read_text()
@@ -528,7 +528,8 @@ class TestSimplePositionStitcher:
             if isinstance(node, ast.FunctionDef) and node.name == 'stitcher_callback'
         )
         callback_source = ast.unparse(callback)
-        assert "result['message']" not in callback_source
+        assert "result.get('reason') == 'unsupported_source_format'" in callback_source
+        assert "result['message']" in callback_source
         assert 'Support > Logs' in callback_source
 
     def test_stitch_ui_explains_modes_and_time_estimation(self):

--- a/ui/file_dialogs.py
+++ b/ui/file_dialogs.py
@@ -38,7 +38,7 @@ _POST_PROCESSING_CONTEXTS = (
 # fires, busy sticks True, and the panel's disabled binding wedges until
 # restart. The other file contexts run synchronously on selection and cannot
 # wedge, so only the executor-backed one is listed.
-_POST_PROCESSING_FILE_CONTEXTS = ('load_quick_enhance_input_image',)
+_POST_PROCESSING_FILE_CONTEXTS = ('choose_quick_enhance_target',)
 
 
 def _zprojection_picker_default_path(live_folder: pathlib.Path) -> str:
@@ -148,6 +148,27 @@ def _macos_choose_folder(initial_dir=None):
     return None
 
 
+def _macos_choose_file_or_folder(initial_dir=None):
+    """Show one native macOS picker that accepts either an image or a folder."""
+    script = 'set theItem to choose file or folder'
+    if initial_dir:
+        script += f' default location POSIX file "{_escape_applescript(initial_dir)}"'
+    script += '\nPOSIX path of theItem'
+
+    try:
+        result = subprocess.run(
+            ['osascript', '-e', script],
+            capture_output=True,
+            text=True,
+            timeout=_MACOS_DIALOG_TIMEOUT_S,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except Exception as e:
+        logger.warning(f'[LVP Main  ] macOS file-or-folder dialog error: {e}')
+    return None
+
+
 def _foregrounded_tk_root():
     """Build the invisible Tk root a tkinter picker parents to, foregrounded.
 
@@ -213,6 +234,44 @@ def _platform_native_open_file(initial_dir, filetypes):
             initialdir=initial_dir,
             filetypes=filetypes,
         )
+    finally:
+        root.destroy()
+    return path or None
+
+
+def _platform_native_choose_file_or_folder(initial_dir, filetypes):
+    """Return one user-chosen file or folder on every supported platform.
+
+    Cocoa has a single native panel for both target kinds. Tk does not, so
+    Windows/Linux present one native yes/no/cancel choice followed by the
+    matching native picker. The LVP panel remains a single visible action.
+    """
+    if sys.platform == 'darwin':
+        return _macos_choose_file_or_folder(initial_dir=initial_dir)
+
+    from tkinter import filedialog, messagebox
+
+    root = _foregrounded_tk_root()
+    try:
+        choose_file = messagebox.askyesnocancel(
+            parent=root,
+            title='Enhance',
+            message='Choose an image file?\nSelect No to choose a folder.',
+        )
+        if choose_file is True:
+            path = filedialog.askopenfilename(
+                parent=root,
+                initialdir=initial_dir,
+                filetypes=filetypes,
+            )
+        elif choose_file is False:
+            path = filedialog.askdirectory(
+                parent=root,
+                initialdir=initial_dir,
+                title='Select folder to enhance',
+            )
+        else:
+            path = ''
     finally:
         root.destroy()
     return path or None
@@ -454,6 +513,59 @@ class FileChooseBTN(HoverBehavior, Button):
 
             elif self.context == 'load_cell_count_method':
                 ctx.cell_count_content.load_method_from_file(file=self.selection[0])
+
+
+class FileOrFolderChooseBTN(HoverBehavior, Button):
+    """One Enhance entry action that accepts either a supported image or a folder."""
+
+    context = StringProperty()
+    selection = ListProperty([])
+
+    def choose(self, context):
+        gui_logger.button('FILE_OR_FOLDER_CHOOSE_OPEN', f'context={context}')
+        logger.info(f'[LVP Main  ] FileOrFolderChooseBTN.choose({context})')
+        self.context = context
+        if context != 'choose_quick_enhance_target':
+            logger.error('Unsupported file-or-folder context: %s', context)
+            return
+
+        initial_dir = str(pathlib.Path(_app_ctx.ctx.settings['live_folder']))
+        filetypes = [('Images', '.tif .tiff .png .jpg .jpeg .bmp')]
+        _run_native_dialog_async(
+            self,
+            lambda: _platform_native_choose_file_or_folder(initial_dir, filetypes),
+            lambda path: self.handle_selection(selection=[path]),
+        )
+
+    def handle_selection(self, selection):
+        if selection:
+            self.selection = selection
+            self.on_selection_function()
+
+    def on_selection_function(self, *a, **k):
+        if not self.selection:
+            return
+        path = pathlib.Path(self.selection[0])
+        gui_logger.select('FILE_OR_FOLDER_CHOOSE', f'context={self.context} path={path}')
+        ctx = _app_ctx.ctx
+        if ctx.protocol_running.is_set():
+            from modules.notification_center import notifications
+
+            notifications.warning(
+                'Post-Processing',
+                'Protocol running',
+                'Post-processing cannot run while a protocol scan is in progress. '
+                'Stop or finish the protocol first, then retry.',
+            )
+            return
+        if path.is_dir():
+            ctx.quick_enhance_controls.set_source_folder(path)
+        elif path.is_file():
+            ctx.quick_enhance_controls.set_source_file(path)
+        else:
+            from modules.notification_center import notifications
+
+            notifications.warning('Enhance', 'Selection unavailable', f'Could not open: {path}')
 
 
 class FolderChooseBTN(HoverBehavior, Button):

--- a/ui/lumaviewpro.kv
+++ b/ui/lumaviewpro.kv
@@ -1765,69 +1765,11 @@
 			size: self.width - dp(4), self.height - dp(4)
 			radius: [dp(8)]
 
-	Label:
-		text: root.warning_text
-		font_size: '11sp'
-		color: 0.86, 0.91, 0.95, 1
-		text_size: self.width - dp(16), None
-		size_hint_y: None
-		height: self.texture_size[1] + dp(12)
-
-	Label:
-		text: 'Input'
-		font_size: '12sp'
-		bold: True
-		color: 0.96, 0.98, 1, 1
-		size_hint_y: None
-		height: '18dp'
-	BoxLayout:
-		size_hint_y: None
-		height: '36dp'
-		QuickEnhanceFileChooseButton:
-			text: 'Choose Image'
-			on_release: self.choose('load_quick_enhance_input_image')
-		QuickEnhanceFolderChooseButton:
-			text: 'Choose Folder'
-			on_release: self.choose('apply_quick_enhance_to_folder')
-	Label:
-		text: 'Quick Enhance'
-		font_size: '12sp'
-		bold: True
-		color: 0.96, 0.98, 1, 1
-		size_hint_y: None
-		height: '18dp'
-	BoxLayout:
-		size_hint_y: None
-		height: '36dp'
-		QuickEnhanceUtilityButton:
-			text: 'Show Original' if root.show_after else 'Show Enhanced'
-			disabled: not root.source_path
-			on_release: root.toggle_before_after()
-		QuickEnhanceUtilityButton:
-			text: 'Update Preview'
-			disabled: not root.source_path
-			on_release: root.refresh_preview()
-	Image:
-		id: quick_enhance_preview_image
-		fit_mode: 'contain'
-		opacity: 1 if self.texture else 0
-		# Under a minimum_height parent, size_hint_y contributes 0 --
-		# bound the preview explicitly: zero when empty (no blank band
-		# before an image loads), a scrollable fixed band when showing.
-		size_hint_y: None
-		height: dp(200) if self.texture else 0
-	QuickEnhancePrimaryButton:
-		text: 'Save Enhanced Image'
+	FileOrFolderChooseBTN:
+		text: 'Enhance'
 		size_hint_y: None
 		height: '38dp'
-		disabled: not root.input_ready
-		on_release: root.export()
-	QuickEnhanceUtilityButton:
-		text: 'Show Output Folder'
-		size_hint_y: None
-		height: '36dp'
-		disabled: not root.last_output_folder
-		on_release: root.open_output_folder()
+		on_release: self.choose('choose_quick_enhance_target')
 	Label:
 		text: root.status_text
 		font_size: '10sp'

--- a/ui/post_processing.py
+++ b/ui/post_processing.py
@@ -27,7 +27,6 @@ from modules.sequential_io_executor import IOTask
 from modules.stitcher import Stitcher
 from modules.composite_generation import CompositeGeneration
 from modules.video_builder import VideoBuilder
-from modules import common_utils
 from modules.common_utils import CustomJSONizer
 import modules.zprojector as zprojector
 import modules.post_processing as post_processing

--- a/ui/post_processing.py
+++ b/ui/post_processing.py
@@ -31,7 +31,7 @@ from modules import common_utils
 from modules.common_utils import CustomJSONizer
 import modules.zprojector as zprojector
 import modules.post_processing as post_processing
-from modules.quick_enhance import QuickEnhanceSettings, QuickEnhancer, QUANTITATIVE_USE_WARNING
+from modules.quick_enhance import QuickEnhanceSettings, QuickEnhancer
 import modules.image_utils as image_utils
 import ui.image_utils_kivy as image_utils_kivy
 import modules.app_context as _app_ctx
@@ -42,138 +42,45 @@ logger = logging.getLogger('LVP.ui.post_processing')
 class QuickEnhanceControls(BoxLayout):
     """GUI shell for the non-destructive Quick Enhance derived-file path."""
 
-    # The caption Label is the ONE rendering home of the disclaimer; it
-    # reflects the store (which export metadata also reads) instead of
-    # duplicating the text, so the wording cannot fork between surfaces.
-    warning_text = QUANTITATIVE_USE_WARNING
-
     done = BooleanProperty(False)
-    source_path = StringProperty('')
-    source_folder = StringProperty('')
     last_output_folder = StringProperty('')
     status_text = StringProperty('')
-    input_ready = BooleanProperty(False)
     busy = BooleanProperty(False)
-    show_after = BooleanProperty(False)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         _app_ctx.register_early('quick_enhance_controls', self)
         self._enhancer = QuickEnhancer()
-        self._source_preview = None
-        self._enhanced_preview = None
-        self._significant_bits = None
         self._export_inflight = False
 
-    def set_source_file(self, file, *, refresh: bool = False) -> None:
-        path = pathlib.Path(file)
-        self.source_path = str(path)
-        self.source_folder = ''
-        self.input_ready = False
-        self.busy = True
-        self.status_text = 'Updating preview...' if refresh else 'Loading image preview...'
-        _app_ctx.ctx.file_io_executor.put(
-            IOTask(
-                action=self._load_preview,
-                args=(path, self._settings()),
-                callback=self._preview_callback,
-                pass_result=True,
-                silent_on_failure=True,
-            )
-        )
+    def set_source_file(self, file) -> None:
+        self._start_export(pathlib.Path(file), target_is_folder=False)
 
     def set_source_folder(self, path) -> None:
-        folder = pathlib.Path(path)
-        self.source_folder = str(folder)
-        self.source_path = ''
-        self.input_ready = folder.is_dir()
-        self.status_text = f'Folder selected: {folder.name}. Folder export is ready; preview controls require Select Image.'
+        self._start_export(pathlib.Path(path), target_is_folder=True)
 
     def _settings(self) -> QuickEnhanceSettings:
         return QuickEnhanceSettings()
 
-    def refresh_preview(self) -> None:
-        if not self.source_path or self.busy:
+    def _start_export(self, target: pathlib.Path, target_is_folder: bool) -> None:
+        if self.busy or self._export_inflight:
+            self.status_text = 'Enhance is already running.'
             return
-        self.set_source_file(self.source_path, refresh=True)
-
-    @staticmethod
-    def _load_preview(path: pathlib.Path, settings: QuickEnhanceSettings) -> dict:
-        enhancer = QuickEnhancer()
-        image, significant_bits = image_utils.load_pixels(path)
-        before, after = enhancer.preview(image, settings, significant_bits)
-        channel = enhancer._source_channel(path)
-        before = enhancer.colorize_mono_for_visual_output(before, channel)
-        after = enhancer.colorize_mono_for_visual_output(after, channel)
-        if channel in common_utils.get_image_layers() and before.ndim == 3:
-            # image_to_texture receives BGR bytes; the false-color helper
-            # deliberately returns RGB for TIFF export and metadata symmetry.
-            before = before[..., ::-1].copy()
-            after = after[..., ::-1].copy()
-        return {
-            'before': before,
-            'after': after,
-            'significant_bits': significant_bits,
-            'detection': 'Fixed recipe: global illumination correction, auto levels, and gentle gamma.',
-        }
-
-    def _preview_callback(self, result=None, exception=None) -> None:
-        self.busy = False
-        if exception is not None or result is None:
-            logger.error('[QuickEnhance] Preview failed', exc_info=exception)
-            self.input_ready = False
-            self.status_text = 'Could not load this image. Choose a supported image file.'
-            return
-        self._source_preview = result['before']
-        self._enhanced_preview = result['after']
-        self._significant_bits = result['significant_bits']
-        self.input_ready = True
-        self.status_text = result['detection']
-        self._show_selected_preview()
-
-    def toggle_before_after(self) -> None:
-        self.show_after = not self.show_after
-        self._show_selected_preview()
-
-    def _show_selected_preview(self) -> None:
-        image = self._enhanced_preview if self.show_after else self._source_preview
-        if image is None or 'quick_enhance_preview_image' not in self.ids:
-            return
-        widget = self.ids['quick_enhance_preview_image']
-        widget.texture = image_utils_kivy.image_to_texture(image, existing=widget.texture)
-
-    def open_output_folder(self) -> None:
-        if not self.last_output_folder:
-            return
-        _app_ctx.ctx.last_save_folder = self.last_output_folder
-        open_last_save_folder()
+        self.busy = True
+        self.status_text = ''
+        self.export(target, target_is_folder)
 
     @show_popup
-    def export(self, popup) -> None:
+    def export(self, popup, target: pathlib.Path, target_is_folder: bool) -> None:
         if self._export_inflight:
-            self.status_text = 'Quick Enhance export is still running in the background.'
-            popup.dismiss()
-            return
-        if not self.input_ready:
+            self.status_text = 'Enhance is already running.'
+            self.busy = False
             popup.dismiss()
             return
         settings = self._settings()
-        errors = self._enhancer.validate(
-            settings,
-            np.dtype(
-                np.uint16 if self._significant_bits and self._significant_bits > 8 else np.uint8
-            ),
-            self._significant_bits or 8,
-        )
-        if errors:
-            self.status_text = ' '.join(errors)
-            popup.dismiss()
-            return
-        target = pathlib.Path(self.source_folder or self.source_path)
-        target_is_folder = bool(self.source_folder)
         self._export_inflight = True
-        popup.title = 'Quick Enhance'
-        popup.text = 'Creating derived image export... Closing this window does not cancel export.'
+        popup.title = 'Enhance'
+        popup.text = ''
         popup.progress = 0
         popup.auto_dismiss = False
         _app_ctx.ctx.file_io_executor.put(
@@ -196,48 +103,72 @@ class QuickEnhanceControls(BoxLayout):
         settings: QuickEnhanceSettings,
     ) -> dict:
         if target_is_folder:
-            return self._enhancer.export_folder(
+            result = self._enhancer.export_folder(
                 target,
                 settings,
                 progress_callback=lambda done, total, path: self._update_folder_progress(
                     popup, done, total, path
                 ),
+                display_callback=self._queue_derived_image,
             )
-        result = self._enhancer.export_file(target, settings)
+            result['target_is_folder'] = True
+            return result
+        result = self._enhancer.export_file(
+            target,
+            settings,
+            display_callback=self._queue_derived_image,
+        )
         self._update_folder_progress(popup, 1, 1, target)
-        return {'status': True, 'created_count': 1, 'created': [result], 'skipped': [], 'total': 1}
+        return {
+            'status': True,
+            'created_count': 1,
+            'created': [result],
+            'skipped': [],
+            'total': 1,
+            'target_is_folder': False,
+        }
 
-    @staticmethod
-    def _update_folder_progress(popup, completed: int, total: int, path: pathlib.Path) -> None:
+    def _update_folder_progress(self, popup, completed: int, total: int, path: pathlib.Path) -> None:
         popup.progress = 100 if total == 0 else (completed / total) * 100
-        popup.text = f'Quick Enhance: {completed}/{total} -- {path.name}'
+        text = f'Image {completed} of {total}'
+        popup.text = text
+        Clock.schedule_once(lambda _dt: setattr(self, 'status_text', text), 0)
+
+    def _queue_derived_image(self, image: np.ndarray, significant_bits: int) -> None:
+        display_image = image.copy()
+
+        def _show(_dt):
+            scope_display = getattr(_app_ctx.ctx, 'scope_display', None)
+            if scope_display is not None:
+                scope_display.hold_derived_image(display_image, significant_bits)
+
+        Clock.schedule_once(_show, 0)
 
     def _export_callback(self, popup, result=None, exception=None) -> None:
-        # busy belongs to the preview path (set/cleared there); the export
-        # path gates on _export_inflight alone, which must clear on every
-        # terminal path so the export button re-enables.
         self._export_inflight = False
+        self.busy = False
         from modules.notification_center import notifications
 
         if exception is not None or result is None:
-            logger.error('[QuickEnhance] Export failed', exc_info=exception)
+            logger.error('[Enhance] Export failed', exc_info=exception)
             popup.dismiss()
-            self.status_text = 'Quick Enhance failed. See the log for details.'
-            notifications.warning('Quick Enhance', 'Export failed', self.status_text)
+            self.status_text = 'Enhance failed. See the log for details.'
+            notifications.warning('Enhance', 'Failed', self.status_text)
             return
         popup.progress = 100
-        created = result['created_count']
-        skipped = len(result['skipped'])
-        summary = f'Created {created} derived image(s).'
-        if skipped:
-            summary += f' Skipped {skipped} unreadable image(s).'
         output_folder = self._enhancer.output_folder(result)
-        if output_folder is not None:
-            self.last_output_folder = str(output_folder)
-            summary += f' Saved in: {output_folder}'
+        if output_folder is None:
+            self.status_text = 'Enhance failed. No supported images were saved.'
+            popup.text = self.status_text
+            return
+        self.last_output_folder = str(output_folder)
+        if result.get('target_is_folder'):
+            saved_path = output_folder
+        else:
+            saved_path = result['created'][0]['output_path']
+        summary = f'Saved: {saved_path}'
         popup.text = summary
         self.status_text = summary
-        notifications.info('Quick Enhance', 'Export complete', summary)
         Clock.schedule_once(lambda _dt: popup.dismiss(), 2)
 
 

--- a/ui/post_processing.py
+++ b/ui/post_processing.py
@@ -242,10 +242,13 @@ class StitchControls(BoxLayout):
 
         final_text = f'Stitching images - {status_map[result["status"]]}'
         if result['status'] is False:
-            final_text = (
-                'Stitching could not be completed for one or more tile groups.\n'
-                'No console error is shown here. Open Support > Logs and search for “Stitcher:”.'
-            )
+            if result.get('reason') == 'unsupported_source_format':
+                final_text = result['message']
+            else:
+                final_text = (
+                    'Stitching could not be completed for one or more tile groups.\n'
+                    'No console error is shown here. Open Support > Logs and search for “Stitcher:”.'
+                )
             popup.text = final_text
             Clock.schedule_once(lambda dt: popup.dismiss(), 5)
             return

--- a/ui/scope_display.py
+++ b/ui/scope_display.py
@@ -1193,6 +1193,32 @@ class ScopeDisplay(Image):
         except Exception as e:
             logger.warning(f'[LVP Main  ] hold_protocol_saved_image failed: {e}')
 
+    def hold_derived_image(self, image, significant_bits):
+        """Show a derived post-processing image briefly in the central viewer.
+
+        Derived color TIFFs are RGB-native, while the Kivy helper accepts BGR
+        display bytes. This path is intentionally separate from the live-camera
+        render loop and uses the same bounded display hold as a saved protocol
+        frame, so a just-created output is visible before live frames resume.
+        """
+        if image is None or getattr(image, 'size', 0) == 0:
+            return
+        try:
+            from ui.image_utils_kivy import image_to_texture
+
+            display = image
+            if display.dtype != np.uint8:
+                display = image_utils.convert_to_8bit(display, significant_bits)
+            if display.ndim == 3:
+                display = display[..., :3][..., ::-1].copy()
+            thread = getattr(_app_ctx.ctx, 'scope_display_thread', None)
+            if thread is not None:
+                thread.bump_protocol_hold(self._PROTOCOL_HOLD_MS / 1000.0)
+            self.texture = image_to_texture(display)
+            self.canvas.ask_update()
+        except Exception as e:
+            logger.warning(f'[LVP Main  ] hold_derived_image failed: {e}')
+
     def _count_display_fps(self):
         """Track actual rendered frame rate (called on main thread after blit).
 


### PR DESCRIPTION
- Simplified Quick Enhance to one cross-platform Enhance action.
- Supports file or folder selection, automatic derived export, progress, output path, and main-viewer display.
- Added Fast Preview versus Quality Stitch documentation.
- Rejects the first JPG or other unsupported source before stitch processing begins.
- Shows an actionable TIFF/OME-TIFF re-acquisition message instead of a generic stitch failure.